### PR TITLE
Fix OpenSSL-breakage

### DIFF
--- a/cscrypt/md5.h
+++ b/cscrypt/md5.h
@@ -7,7 +7,6 @@
 #define MD5_DIGEST_LENGTH 16
 
 unsigned char *MD5(const unsigned char *input, unsigned long len, unsigned char *output_hash);
-#endif
 
 typedef struct MD5Context {
 	uint32_t buf[4];
@@ -19,5 +18,6 @@ char * __md5_crypt(const char *text_pass, const char *salt, char *crypted_passwd
 void MD5_Init(MD5_CTX *ctx);
 void MD5_Update(MD5_CTX *ctx, const unsigned char *buf, unsigned int len);
 void MD5_Final(unsigned char digest[MD5_DIGEST_LENGTH], MD5_CTX *ctx);
+#endif
 
 #endif

--- a/emulator.c
+++ b/emulator.c
@@ -443,7 +443,7 @@ char SoftNDSECM(unsigned char *ecm, unsigned char *dw)
 	int i;
 	unsigned char *tDW;
 	unsigned char digest[16];
-	struct MD5Context mdContext;
+	MD5_CTX mdContext;
 	memset(dw,0,16);
 	tDW = &dw[ecm[0]==0x81 ? 8 : 0];
 	if (ecm[6]!=0x21) return 1;


### PR DESCRIPTION
Should fix WITH_SSL=1 and WITH_CRYPTO=1
But as stated, MD5 part needs some serious rework not to depend on cscrypt/md5.*
