### PR TITLE
fixed logical error for unusual Viaccess ECMs

### DIFF
--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -1195,7 +1195,7 @@ Index: module-emulator.c
 +						if (ecm[keySelectPos]==0x05 && ecm[keySelectPos+1]==0x67 && (ecm[keySelectPos+2]==0x00 || ecm[keySelectPos+2]==0x01)) {
 +							if(ecm[keySelectPos+2]==0x01) doFinalMix = true;
 +						}
-+						else return 4;
++						else break;
 +					}
 +					return Via3Decrypt(ecm + i, dw, currentIdent, desKeyIndex, aesKeyIndex, aesMode, doFinalMix);
 +				}


### PR DESCRIPTION
I overlooked this error during my inital testing because only one channel is affected currently.
