### PR TITLE
Update oscam-emu.patch

### DIFF
--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -1,14 +1,5 @@
-Index: .travis.yml
-===================================================================
---- .travis.yml	(nonexistent)
-+++ .travis.yml	(working copy)
-@@ -0,0 +1,2 @@
-+language: cpp
-+script: ./config.sh -E all && make
-Index: CMakeLists.txt
-===================================================================
---- CMakeLists.txt	(revision 11581)
-+++ CMakeLists.txt	(working copy)
+--- oscam-svn/CMakeLists.txt	2020-09-23 22:18:25.000000000 +0200
++++ oscam-svn/CMakeLists.txt	2020-09-23 22:57:35.768431210 +0200
 @@ -101,6 +101,7 @@
  		${CMAKE_CURRENT_SOURCE_DIR}/csctapi
  		${CMAKE_CURRENT_SOURCE_DIR}/cscrypt
@@ -113,10 +104,120 @@ Index: CMakeLists.txt
 +endif (WITH_EMU)
 +
  message (STATUS "")
-Index: Makefile
-===================================================================
---- Makefile	(revision 11581)
-+++ Makefile	(working copy)
+--- oscam-svn/config.h	2020-09-23 22:18:25.000000000 +0200
++++ oscam-svn/config.h	2020-09-23 22:57:35.768431210 +0200
+@@ -1,6 +1,8 @@
+ #ifndef CONFIG_H_
+ #define CONFIG_H_
+ 
++#define WITH_EMU 1
++#define WITH_SOFTCAM 1
+ #define WEBIF 1
+ #define WEBIF_LIVELOG 1
+ #define WEBIF_JQUERY 1
+--- oscam-svn/config.sh	2020-09-23 22:18:25.000000000 +0200
++++ oscam-svn/config.sh	2020-09-23 23:00:02.167353804 +0200
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-addons="WEBIF WEBIF_LIVELOG WEBIF_JQUERY TOUCH WITH_SSL HAVE_DVBAPI WITH_NEUTRINO READ_SDT_CHARSETS IRDETO_GUESSING CS_ANTICASC WITH_DEBUG MODULE_MONITOR WITH_LB CS_CACHEEX CS_CACHEEX_AIO CW_CYCLE_CHECK LCDSUPPORT LEDSUPPORT CLOCKFIX IPV6SUPPORT"
++addons="WEBIF WEBIF_LIVELOG WEBIF_JQUERY TOUCH WITH_SSL HAVE_DVBAPI WITH_NEUTRINO READ_SDT_CHARSETS IRDETO_GUESSING CS_ANTICASC WITH_DEBUG MODULE_MONITOR WITH_LB CS_CACHEEX CS_CACHEEX_AIO CW_CYCLE_CHECK LCDSUPPORT LEDSUPPORT CLOCKFIX IPV6SUPPORT WITH_EMU WITH_SOFTCAM"
+ protocols="MODULE_CAMD33 MODULE_CAMD35 MODULE_CAMD35_TCP MODULE_NEWCAMD MODULE_CCCAM MODULE_CCCSHARE MODULE_GBOX MODULE_RADEGAST MODULE_SCAM MODULE_SERIAL MODULE_CONSTCW MODULE_PANDORA MODULE_GHTTP"
+ readers="READER_NAGRA READER_NAGRA_MERLIN READER_IRDETO READER_CONAX READER_CRYPTOWORKS READER_SECA READER_VIACCESS READER_VIDEOGUARD READER_DRE READER_TONGFANG READER_BULCRYPT READER_GRIFFIN READER_DGCRYPT"
+ card_readers="CARDREADER_PHOENIX CARDREADER_INTERNAL CARDREADER_SC8IN1 CARDREADER_MP35 CARDREADER_SMARGO CARDREADER_DB2COM CARDREADER_STAPI CARDREADER_STAPI5 CARDREADER_STINGER CARDREADER_DRECAS"
+@@ -26,6 +26,8 @@
+ # CONFIG_LEDSUPPORT=n
+ # CONFIG_CLOCKFIX=n
+ # CONFIG_IPV6SUPPORT=n
++CONFIG_WITH_EMU=y
++CONFIG_WITH_SOFTCAM=y
+ # CONFIG_MODULE_CAMD33=n
+ CONFIG_MODULE_CAMD35=y
+ CONFIG_MODULE_CAMD35_TCP=y
+@@ -293,13 +295,16 @@
+ 
+ update_deps() {
+ 	# Calculate dependencies
+-	enabled_any $(get_opts readers) $(get_opts card_readers) && enable_opt WITH_CARDREADER >/dev/null
+-	disabled_all $(get_opts readers) $(get_opts card_readers) && disable_opt WITH_CARDREADER >/dev/null
++	enabled_any $(get_opts readers) $(get_opts card_readers) WITH_EMU && enable_opt WITH_CARDREADER >/dev/null
++	disabled_all $(get_opts readers) $(get_opts card_readers) WITH_EMU && disable_opt WITH_CARDREADER >/dev/null
+ 	disabled WEBIF && disable_opt WEBIF_LIVELOG >/dev/null
+ 	disabled WEBIF && disable_opt WEBIF_JQUERY >/dev/null
+ 	enabled MODULE_CCCSHARE && enable_opt MODULE_CCCAM >/dev/null
+ 	enabled_any CARDREADER_DB2COM CARDREADER_MP35 CARDREADER_SC8IN1 CARDREADER_STINGER && enable_opt CARDREADER_PHOENIX >/dev/null
+ 	enabled CS_CACHEEX_AIO && enable_opt CS_CACHEEX >/dev/null
++	enabled WITH_EMU && enable_opt READER_VIACCESS >/dev/null
++	enabled WITH_EMU && enable_opt MODULE_NEWCAMD >/dev/null
++	disabled WITH_EMU && disable_opt WITH_SOFTCAM >/dev/null
+ }
+ 
+ list_config() {
+@@ -349,9 +354,9 @@
+ 	not_have_flag USE_LIBCRYPTO && echo "CONFIG_LIB_AES=y" || echo "# CONFIG_LIB_AES=n"
+ 	enabled MODULE_CCCAM && echo "CONFIG_LIB_RC6=y" || echo "# CONFIG_LIB_RC6=n"
+ 	not_have_flag USE_LIBCRYPTO && enabled MODULE_CCCAM && echo "CONFIG_LIB_SHA1=y" || echo "# CONFIG_LIB_SHA1=n"
+-	enabled_any READER_DRE MODULE_SCAM READER_VIACCESS READER_NAGRA_MERLIN READER_VIDEOGUARD && echo "CONFIG_LIB_DES=y" || echo "# CONFIG_LIB_DES=n"
+-	enabled_any MODULE_CCCAM READER_NAGRA READER_NAGRA_MERLIN READER_SECA && echo "CONFIG_LIB_IDEA=y" || echo "# CONFIG_LIB_IDEA=n"
+-	not_have_flag USE_LIBCRYPTO && enabled_any READER_CONAX READER_CRYPTOWORKS READER_NAGRA READER_NAGRA_MERLIN && echo "CONFIG_LIB_BIGNUM=y" || echo "# CONFIG_LIB_BIGNUM=n"
++	enabled_any READER_DRE MODULE_SCAM READER_VIACCESS READER_NAGRA_MERLIN READER_VIDEOGUARD WITH_EMU && echo "CONFIG_LIB_DES=y" || echo "# CONFIG_LIB_DES=n"
++	enabled_any MODULE_CCCAM READER_NAGRA READER_NAGRA_MERLIN READER_SECA WITH_EMU && echo "CONFIG_LIB_IDEA=y" || echo "# CONFIG_LIB_IDEA=n"
++	not_have_flag USE_LIBCRYPTO && enabled_any READER_CONAX READER_CRYPTOWORKS READER_NAGRA READER_NAGRA_MERLIN WITH_EMU && echo "CONFIG_LIB_BIGNUM=y" || echo "# CONFIG_LIB_BIGNUM=n"
+ 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_MDC2=y" || echo "# CONFIG_LIB_MDC2=n"
+ 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_FAST_AES=y" || echo "# CONFIG_LIB_FAST_AES=n"
+ 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_SHA256=y" || echo "# CONFIG_LIB_SHA256=n"
+@@ -468,6 +473,8 @@
+ 		LEDSUPPORT			"LED support"							$(check_test "LEDSUPPORT") \
+ 		CLOCKFIX			"Clockfix (disable on old systems!)"	$(check_test "CLOCKFIX") \
+ 		IPV6SUPPORT			"IPv6 support (experimental)"			$(check_test "IPV6SUPPORT") \
++		WITH_EMU			"Emulator support"						$(check_test "WITH_EMU") \
++		WITH_SOFTCAM		"Built-in SoftCam.Key"					$(check_test "WITH_SOFTCAM") \
+ 		2> ${tempfile}
+ 
+ 	opt=${?}
+@@ -704,9 +711,19 @@
+ 		revision=`(svnversion -n . 2>/dev/null || printf 0) | sed 's/.*://; s/[^0-9]*$//; s/^$/0/'`
+ 		if [ "$revision" = "0" ]
+ 		then
+-			which git > /dev/null 2>&1 && revision=`git log -10 --pretty=%B | grep git-svn-id | head -n 1 | sed -n -e 's/^.*trunk@\([0-9]*\) .*$/\1/p'`
++			which git > /dev/null 2>&1 && revision=`git log -25 --pretty=%B | grep git-svn-id | head -n 1 | sed -n -e 's/^.*trunk@\([0-9]*\) .*$/\1/p'`
+ 		fi
+-		echo $revision
++		emuversion=`grep EMU_VERSION module-emulator-osemu.h | awk '{ print $3 }'`
++		if [ -z "$emuversion" ]
++		then
++			echo "$revision"
++		else
++			echo "$revision-$emuversion"
++		fi
++		break
++	;;
++	'--emu-version')
++		grep EMU_VERSION module-emulator-osemu.h | awk '{ print $3 }'
+ 		break
+ 	;;
+ 	'-O'|'--detect-osx-sdk-version')
+--- oscam-svn/globals.h	2020-09-23 22:18:25.000000000 +0200
++++ oscam-svn/globals.h	2020-09-23 22:57:35.772490349 +0200
+@@ -393,7 +393,7 @@
+ #define CS_ECM_RINGBUFFER_MAX	0x10	// max size for ECM last responsetimes ringbuffer. Keep this set to power of 2 values!
+ 
+ // Support for multiple CWs per channel and other encryption algos
+-//#define WITH_EXTENDED_CW		1
++#define WITH_EXTENDED_CW		1
+ 
+ #if defined(READER_DRE) || defined(READER_DRECAS) || defined(READER_VIACCESS) || defined(WITH_EMU)
+ #define MAX_ECM_SIZE			1024
+@@ -1856,6 +1856,7 @@
+ #ifdef WITH_EMU
+ 	FTAB			emu_auproviders;				// AU providers for Emu reader
+ 	int8_t			emu_datecodedenabled;			// date-coded keys for BISS
++	LLIST			*ll_biss2_rsa_keys;				// BISS2 RSA keys - Read from external PEM files
+ #endif
+ 	uint8_t			cnxlastecm;						// == 0 - last ecm has not been paired ecm, > 0 last ecm has been paired ecm
+ 	LLIST			*emmstat;						// emm stats
+--- oscam-svn/Makefile	2020-09-23 22:18:26.000000000 +0200
++++ oscam-svn/Makefile	2020-09-23 22:57:35.768431210 +0200
 @@ -65,6 +65,13 @@
  
  LDFLAGS = -Wl,--gc-sections
@@ -171,131 +272,9 @@ Index: Makefile
  	@-printf "\
  +-------------------------------------------------------------------------------\n\
  | OSCam ver: $(VER) rev: $(SVN_REV) target: $(TARGET)\n\
-Index: config.h
-===================================================================
---- config.h	(revision 11581)
-+++ config.h	(working copy)
-@@ -1,6 +1,8 @@
- #ifndef CONFIG_H_
- #define CONFIG_H_
- 
-+#define WITH_EMU 1
-+#define WITH_SOFTCAM 1
- #define WEBIF 1
- #define WEBIF_LIVELOG 1
- #define WEBIF_JQUERY 1
-Index: config.sh
-===================================================================
---- config.sh	(revision 11581)
-+++ config.sh	(working copy)
-@@ -1,6 +1,6 @@
- #!/bin/sh
- 
--addons="WEBIF WEBIF_LIVELOG WEBIF_JQUERY TOUCH WITH_SSL HAVE_DVBAPI WITH_NEUTRINO READ_SDT_CHARSETS IRDETO_GUESSING CS_ANTICASC WITH_DEBUG MODULE_MONITOR WITH_LB CS_CACHEEX CW_CYCLE_CHECK LCDSUPPORT LEDSUPPORT CLOCKFIX IPV6SUPPORT"
-+addons="WEBIF WEBIF_LIVELOG WEBIF_JQUERY TOUCH WITH_SSL HAVE_DVBAPI WITH_NEUTRINO READ_SDT_CHARSETS IRDETO_GUESSING CS_ANTICASC WITH_DEBUG MODULE_MONITOR WITH_LB CS_CACHEEX CW_CYCLE_CHECK LCDSUPPORT LEDSUPPORT CLOCKFIX IPV6SUPPORT WITH_EMU WITH_SOFTCAM"
- protocols="MODULE_CAMD33 MODULE_CAMD35 MODULE_CAMD35_TCP MODULE_NEWCAMD MODULE_CCCAM MODULE_CCCSHARE MODULE_GBOX MODULE_RADEGAST MODULE_SCAM MODULE_SERIAL MODULE_CONSTCW MODULE_PANDORA MODULE_GHTTP"
- readers="READER_NAGRA READER_NAGRA_MERLIN READER_IRDETO READER_CONAX READER_CRYPTOWORKS READER_SECA READER_VIACCESS READER_VIDEOGUARD READER_DRE READER_TONGFANG READER_BULCRYPT READER_GRIFFIN READER_DGCRYPT"
- card_readers="CARDREADER_PHOENIX CARDREADER_INTERNAL CARDREADER_SC8IN1 CARDREADER_MP35 CARDREADER_SMARGO CARDREADER_DB2COM CARDREADER_STAPI CARDREADER_STAPI5 CARDREADER_STINGER CARDREADER_DRECAS"
-@@ -25,6 +25,8 @@
- # CONFIG_LEDSUPPORT=n
- # CONFIG_CLOCKFIX=n
- # CONFIG_IPV6SUPPORT=n
-+CONFIG_WITH_EMU=y
-+CONFIG_WITH_SOFTCAM=y
- # CONFIG_MODULE_CAMD33=n
- CONFIG_MODULE_CAMD35=y
- CONFIG_MODULE_CAMD35_TCP=y
-@@ -292,12 +294,15 @@
- 
- update_deps() {
- 	# Calculate dependencies
--	enabled_any $(get_opts readers) $(get_opts card_readers) && enable_opt WITH_CARDREADER >/dev/null
--	disabled_all $(get_opts readers) $(get_opts card_readers) && disable_opt WITH_CARDREADER >/dev/null
-+	enabled_any $(get_opts readers) $(get_opts card_readers) WITH_EMU && enable_opt WITH_CARDREADER >/dev/null
-+	disabled_all $(get_opts readers) $(get_opts card_readers) WITH_EMU && disable_opt WITH_CARDREADER >/dev/null
- 	disabled WEBIF && disable_opt WEBIF_LIVELOG >/dev/null
- 	disabled WEBIF && disable_opt WEBIF_JQUERY >/dev/null
- 	enabled MODULE_CCCSHARE && enable_opt MODULE_CCCAM >/dev/null
- 	enabled_any CARDREADER_DB2COM CARDREADER_MP35 CARDREADER_SC8IN1 CARDREADER_STINGER && enable_opt CARDREADER_PHOENIX >/dev/null
-+	enabled WITH_EMU && enable_opt READER_VIACCESS >/dev/null
-+	enabled WITH_EMU && enable_opt MODULE_NEWCAMD >/dev/null
-+	disabled WITH_EMU && disable_opt WITH_SOFTCAM >/dev/null
- }
- 
- list_config() {
-@@ -347,9 +352,9 @@
- 	not_have_flag USE_LIBCRYPTO && echo "CONFIG_LIB_AES=y" || echo "# CONFIG_LIB_AES=n"
- 	enabled MODULE_CCCAM && echo "CONFIG_LIB_RC6=y" || echo "# CONFIG_LIB_RC6=n"
- 	not_have_flag USE_LIBCRYPTO && enabled MODULE_CCCAM && echo "CONFIG_LIB_SHA1=y" || echo "# CONFIG_LIB_SHA1=n"
--	enabled_any READER_DRE MODULE_SCAM READER_VIACCESS READER_NAGRA_MERLIN READER_VIDEOGUARD && echo "CONFIG_LIB_DES=y" || echo "# CONFIG_LIB_DES=n"
--	enabled_any MODULE_CCCAM READER_NAGRA READER_NAGRA_MERLIN READER_SECA && echo "CONFIG_LIB_IDEA=y" || echo "# CONFIG_LIB_IDEA=n"
--	not_have_flag USE_LIBCRYPTO && enabled_any READER_CONAX READER_CRYPTOWORKS READER_NAGRA READER_NAGRA_MERLIN && echo "CONFIG_LIB_BIGNUM=y" || echo "# CONFIG_LIB_BIGNUM=n"
-+	enabled_any READER_DRE MODULE_SCAM READER_VIACCESS READER_NAGRA_MERLIN READER_VIDEOGUARD WITH_EMU && echo "CONFIG_LIB_DES=y" || echo "# CONFIG_LIB_DES=n"
-+	enabled_any MODULE_CCCAM READER_NAGRA READER_NAGRA_MERLIN READER_SECA WITH_EMU && echo "CONFIG_LIB_IDEA=y" || echo "# CONFIG_LIB_IDEA=n"
-+	not_have_flag USE_LIBCRYPTO && enabled_any READER_CONAX READER_CRYPTOWORKS READER_NAGRA READER_NAGRA_MERLIN WITH_EMU && echo "CONFIG_LIB_BIGNUM=y" || echo "# CONFIG_LIB_BIGNUM=n"
- 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_MDC2=y" || echo "# CONFIG_LIB_MDC2=n"
- 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_FAST_AES=y" || echo "# CONFIG_LIB_FAST_AES=n"
- 	enabled READER_NAGRA_MERLIN && echo "CONFIG_LIB_SHA256=y" || echo "# CONFIG_LIB_SHA256=n"
-@@ -465,6 +470,8 @@
- 		LEDSUPPORT			"LED support"							$(check_test "LEDSUPPORT") \
- 		CLOCKFIX			"Clockfix (disable on old systems!)"	$(check_test "CLOCKFIX") \
- 		IPV6SUPPORT			"IPv6 support (experimental)"			$(check_test "IPV6SUPPORT") \
-+		WITH_EMU			"Emulator support"						$(check_test "WITH_EMU") \
-+		WITH_SOFTCAM		"Built-in SoftCam.Key"					$(check_test "WITH_SOFTCAM") \
- 		2> ${tempfile}
- 
- 	opt=${?}
-@@ -701,9 +708,19 @@
- 		revision=`(svnversion -n . 2>/dev/null || printf 0) | sed 's/.*://; s/[^0-9]*$//; s/^$/0/'`
- 		if [ "$revision" = "0" ]
- 		then
--			which git > /dev/null 2>&1 && revision=`git log -10 --pretty=%B | grep git-svn-id | head -n 1 | sed -n -e 's/^.*trunk@\([0-9]*\) .*$/\1/p'`
-+			which git > /dev/null 2>&1 && revision=`git log -25 --pretty=%B | grep git-svn-id | head -n 1 | sed -n -e 's/^.*trunk@\([0-9]*\) .*$/\1/p'`
- 		fi
--		echo $revision
-+		emuversion=`grep EMU_VERSION module-emulator-osemu.h | awk '{ print $3 }'`
-+		if [ -z "$emuversion" ]
-+		then
-+			echo "$revision"
-+		else
-+			echo "$revision-$emuversion"
-+		fi
-+		break
-+	;;
-+	'--emu-version')
-+		grep EMU_VERSION module-emulator-osemu.h | awk '{ print $3 }'
- 		break
- 	;;
- 	'-O'|'--detect-osx-sdk-version')
-Index: git-svn-diff.sh
-old mode 100644
-new mode 100755
-Index: globals.h
-===================================================================
---- globals.h	(revision 11581)
-+++ globals.h	(working copy)
-@@ -388,7 +388,7 @@
- #define CS_ECM_RINGBUFFER_MAX	0x10	// max size for ECM last responsetimes ringbuffer. Keep this set to power of 2 values!
- 
- // Support for multiple CWs per channel and other encryption algos
--//#define WITH_EXTENDED_CW		1
-+#define WITH_EXTENDED_CW		1
- 
- #if defined(READER_DRE) || defined(READER_DRECAS) || defined(READER_VIACCESS) || defined(WITH_EMU)
- #define MAX_ECM_SIZE			1024
-@@ -1792,6 +1792,7 @@
- #ifdef WITH_EMU
- 	FTAB			emu_auproviders;				// AU providers for Emu reader
- 	int8_t			emu_datecodedenabled;			// date-coded keys for BISS
-+	LLIST			*ll_biss2_rsa_keys;				// BISS2 RSA keys - Read from external PEM files
- #endif
- 	uint8_t			cnxlastecm;						// == 0 - last ecm has not been paired ecm, > 0 last ecm has been paired ecm
- 	LLIST			*emmstat;						// emm stats
-Index: module-dvbapi.c
-===================================================================
---- module-dvbapi.c	(revision 11581)
-+++ module-dvbapi.c	(working copy)
-@@ -2632,6 +2632,8 @@
+--- oscam-svn/module-dvbapi.c	2020-09-23 22:18:26.000000000 +0200
++++ oscam-svn/module-dvbapi.c	2020-09-23 22:57:35.772490349 +0200
+@@ -2644,6 +2644,8 @@
  	er->vpid   = demux[demux_id].ECMpids[pid].VPID;
  	er->pmtpid = demux[demux_id].pmtpid;
  	er->onid   = demux[demux_id].onid;
@@ -304,7 +283,7 @@ Index: module-dvbapi.c
  	er->msgid  = msgid;
  
  #ifdef WITH_STAPI5
-@@ -2679,19 +2681,30 @@
+@@ -2691,19 +2693,30 @@
  		if(caid_is_fake(demux[demux_id].ECMpids[pid].CAID) || caid_is_biss_fixed(demux[demux_id].ECMpids[pid].CAID))
  		{
  			int32_t j, n;
@@ -338,10 +317,8 @@ Index: module-dvbapi.c
  			cs_log("Demuxer %d trying to descramble PID %d CAID %04X PROVID %06X ECMPID %04X ANY CHID PMTPID %04X VPID %04X",
  				demux_id,
  				pid,
-Index: module-emulator-biss.c
-===================================================================
---- module-emulator-biss.c	(nonexistent)
-+++ module-emulator-biss.c	(working copy)
+--- oscam-svn/module-emulator-biss.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-biss.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,894 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -1237,10 +1214,8 @@ Index: module-emulator-biss.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-biss.h
-===================================================================
---- module-emulator-biss.h	(nonexistent)
-+++ module-emulator-biss.h	(working copy)
+--- oscam-svn/module-emulator-biss.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-biss.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,22 @@
 +#ifndef MODULE_EMULATOR_BISS_H
 +#define MODULE_EMULATOR_BISS_H
@@ -1264,10 +1239,915 @@ Index: module-emulator-biss.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_BISS_H
-Index: module-emulator-cryptoworks.c
-===================================================================
---- module-emulator-cryptoworks.c	(nonexistent)
-+++ module-emulator-cryptoworks.c	(working copy)
+--- oscam-svn/module-emulator.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator.c	2020-09-23 22:57:35.776549489 +0200
+@@ -0,0 +1,904 @@
++#define MODULE_LOG_PREFIX "emu"
++
++#include "globals.h"
++
++#ifdef WITH_EMU
++
++#include "module-emulator-osemu.h"
++#include "module-emulator-streamserver.h"
++#include "module-emulator-biss.h"
++#include "module-emulator-irdeto.h"
++#include "module-emulator-powervu.h"
++#include "oscam-conf-chk.h"
++#include "oscam-config.h"
++#include "oscam-reader.h"
++#include "oscam-string.h"
++
++/*
++ * Readers in OSCam consist of 2 basic parts.
++ * The hardware or the device part. This is where physical smart cards are inserted
++ * and made available to OSCam.
++ * The software or the emulation part. This is where the actual card reading is done,
++ * including ecm and emm processing (i.e emulation of the various cryptosystems).
++ * In the Emu reader, the device part has no meaning, but we have to create it in
++ * order to be compatible with OSCam's reader structure.
++*/
++
++/*
++ * Create the Emu "emulation" part. This is of type s_cardsystem.
++ * Similar structures are found in the main sources folder (files reader-xxxxxx.c)
++ * for every cryptosystem supported by OSCam.
++ * Here we read keys from our virtual card (aka the SoftCam.Key file) and we inform
++ * OSCam about them. This is done with the emu_card_info() function. Keep in mind
++ * that Emu holds all its keys to separate structures for faster access.
++ * In addition, ECM and EMM requests are processed here, with the emu_do_ecm() and
++ * emu_do_emm() functions.
++*/
++
++#define CS_OK    1
++#define CS_ERROR 0
++
++extern char cs_confdir[128];
++static int8_t emu_key_data_mutex_init = 0;
++pthread_mutex_t emu_key_data_mutex;
++
++static void set_hexserial_to_version(struct s_reader *rdr)
++{
++	char cVersion[32];
++	uint32_t version = EMU_VERSION;
++	uint8_t hversion[2];
++	memset(hversion, 0, 2);
++	snprintf(cVersion, sizeof(cVersion), "%04d", version);
++	char_to_bin(hversion, cVersion, 4);
++	rdr->hexserial[3] = hversion[0];
++	rdr->hexserial[4] = hversion[1];
++}
++
++static void set_prids(struct s_reader *rdr)
++{
++	int32_t i, j;
++
++	rdr->nprov = 0;
++
++	for (i = 0; (i < rdr->emu_auproviders.nfilts) && (rdr->nprov < CS_MAXPROV); i++)
++	{
++		for (j = 0; (j < rdr->emu_auproviders.filts[i].nprids) && (rdr->nprov < CS_MAXPROV); j++)
++		{
++			i2b_buf(4, rdr->emu_auproviders.filts[i].prids[j], rdr->prid[i]);
++			rdr->nprov++;
++		}
++	}
++}
++
++static void emu_add_entitlement(struct s_reader *rdr, uint16_t caid, uint32_t provid, uint8_t *key, char *keyName, uint32_t keyLength, uint8_t isData)
++{
++	if (!rdr->ll_entitlements)
++	{
++		rdr->ll_entitlements = ll_create("ll_entitlements");
++	}
++
++	S_ENTITLEMENT *item;
++	if (cs_malloc(&item, sizeof(S_ENTITLEMENT)))
++	{
++		// fill item
++		item->caid = caid;
++		item->provid = provid;
++		item->id = 0;
++		item->class = 0;
++		item->start = 0;
++		item->end = 2147472000;
++		item->type = 0;
++		item->isKey = 1;
++		memcpy(item->name, keyName, 8);
++		item->key = key;
++		item->keyLength = keyLength;
++		item->isData = isData;
++
++		// add item
++		ll_append(rdr->ll_entitlements, item);
++	}
++}
++
++static void refresh_entitlements(struct s_reader *rdr)
++{
++	uint32_t i;
++	uint16_t caid;
++	KeyData *tmpKeyData;
++	LL_ITER itr;
++	biss2_rsa_key_t *item;
++
++	cs_clear_entitlement(rdr);
++
++	for (i = 0; i < StreamKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, b2i(2, StreamKeys.EmuKeys[i].key), StreamKeys.EmuKeys[i].provider, StreamKeys.EmuKeys[i].key,
++							StreamKeys.EmuKeys[i].keyName, StreamKeys.EmuKeys[i].keyLength, 1);
++	}
++
++	for (i = 0; i < ViKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x0500, ViKeys.EmuKeys[i].provider, ViKeys.EmuKeys[i].key,
++							ViKeys.EmuKeys[i].keyName, ViKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < IrdetoKeys.keyCount; i++)
++	{
++		tmpKeyData = &IrdetoKeys.EmuKeys[i];
++		do
++		{
++			emu_add_entitlement(rdr, tmpKeyData->provider >> 8, tmpKeyData->provider & 0xFF,
++								tmpKeyData->key, tmpKeyData->keyName, tmpKeyData->keyLength, 0);
++
++			tmpKeyData = tmpKeyData->nextKey;
++		}
++		while (tmpKeyData != NULL);
++	}
++
++	for (i = 0; i < CwKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, CwKeys.EmuKeys[i].provider >> 8, CwKeys.EmuKeys[i].provider & 0xFF,
++							CwKeys.EmuKeys[i].key, CwKeys.EmuKeys[i].keyName, CwKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < PowervuKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x0E00, PowervuKeys.EmuKeys[i].provider, PowervuKeys.EmuKeys[i].key,
++							PowervuKeys.EmuKeys[i].keyName, PowervuKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < TandbergKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x1010, TandbergKeys.EmuKeys[i].provider, TandbergKeys.EmuKeys[i].key,
++							TandbergKeys.EmuKeys[i].keyName, TandbergKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < NagraKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x1801, NagraKeys.EmuKeys[i].provider, NagraKeys.EmuKeys[i].key,
++							NagraKeys.EmuKeys[i].keyName, NagraKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	// Session words for BISS1 mode 1/E (caid 2600) and BISS2 mode 1/E (caid 2602)
++	for (i = 0; i < BissSWs.keyCount; i++)
++	{
++		caid = (BissSWs.EmuKeys[i].keyLength == 8) ? 0x2600 : 0x2602;
++		emu_add_entitlement(rdr, caid, BissSWs.EmuKeys[i].provider, BissSWs.EmuKeys[i].key,
++							BissSWs.EmuKeys[i].keyName, BissSWs.EmuKeys[i].keyLength, 0);
++	}
++
++	// Session keys (ECM keys) for BISS2 mode CA
++	for (i = 0; i < Biss2Keys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x2610, Biss2Keys.EmuKeys[i].provider, Biss2Keys.EmuKeys[i].key,
++							Biss2Keys.EmuKeys[i].keyName, Biss2Keys.EmuKeys[i].keyLength, 0);
++	}
++
++	// RSA keys (EMM keys) for BISS2 mode CA
++	itr = ll_iter_create(rdr->ll_biss2_rsa_keys);
++	while ((item = ll_iter_next(&itr)))
++	{
++		emu_add_entitlement(rdr, 0x2610, 0, item->ekid, "RSAPRI", 8, 0);
++	}
++}
++
++static int32_t emu_do_ecm(struct s_reader *rdr, const ECM_REQUEST *er, struct s_ecm_answer *ea)
++{
++	if (!emu_process_ecm(rdr, er, ea->cw, &ea->cw_ex))
++	{
++		return CS_OK;
++	}
++
++	return CS_ERROR;
++}
++
++static int32_t emu_do_emm(struct s_reader *rdr, EMM_PACKET *emm)
++{
++	uint32_t keysAdded = 0;
++
++	if (emm->emmlen < 3)
++	{
++		return CS_ERROR;
++	}
++
++	if (SCT_LEN(emm->emm) > emm->emmlen)
++	{
++		return CS_ERROR;
++	}
++
++	if (!emu_process_emm(rdr, b2i(2, emm->caid), emm->emm, &keysAdded))
++	{
++		if (keysAdded > 0)
++		{
++			refresh_entitlements(rdr);
++		}
++
++		return CS_OK;
++	}
++
++	return CS_ERROR;
++}
++
++static int32_t emu_card_info(struct s_reader *rdr)
++{
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++
++	// Delete keys from Emu's memory
++	emu_clear_keydata();
++
++	// Delete BISS2 mode CA RSA keys
++	ll_destroy_data(&rdr->ll_biss2_rsa_keys);
++
++	// Read keys built in the OSCam-Emu binary
++	emu_read_keymemory(rdr);
++
++	// Read keys from SoftCam.Key file
++	emu_set_keyfile_path(cs_confdir);
++
++	if (!emu_read_keyfile(rdr, cs_confdir))
++	{
++		if (emu_read_keyfile(rdr, "/var/keys/"))
++		{
++			emu_set_keyfile_path("/var/keys/");
++		}
++	}
++
++	// Read BISS2 mode CA RSA keys from PEM files
++	biss_read_pem(rdr, BISS2_MAX_RSA_KEYS);
++
++	cs_log("Total keys in memory: W:%d V:%d N:%d I:%d F:%d G:%d P:%d T:%d A:%d",
++			CwKeys.keyCount, ViKeys.keyCount, NagraKeys.keyCount, IrdetoKeys.keyCount,
++			BissSWs.keyCount, Biss2Keys.keyCount, PowervuKeys.keyCount, TandbergKeys.keyCount,
++			StreamKeys.keyCount);
++
++	// Inform OSCam about all available keys.
++	// This is used for listing the "entitlements" in the webif's reader page.
++	refresh_entitlements(rdr);
++
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	set_prids(rdr);
++
++	set_hexserial_to_version(rdr);
++
++	return CS_OK;
++}
++
++/*
++static int32_t emu_card_init(struct s_reader *UNUSED(rdr), struct s_ATR *UNUSED(atr))
++{
++	return CS_ERROR;
++}
++*/
++
++int32_t emu_get_via3_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	uint32_t provid = 0;
++
++	if(ep->emm[3] == 0x90 && ep->emm[4] == 0x03)
++	{
++		provid = b2i(3, ep->emm + 5);
++		provid &= 0xFFFFF0;
++		i2b_buf(4, provid, ep->provid);
++	}
++
++	switch (ep->emm[0])
++	{
++		case 0x88:
++			ep->type = UNIQUE;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, 4);
++			rdr_log_dbg(rdr, D_EMM, "UNIQUE");
++			return 1;
++
++		case 0x8A:
++		case 0x8B:
++			ep->type = GLOBAL;
++			rdr_log_dbg(rdr, D_EMM, "GLOBAL");
++			return 1;
++
++		case 0x8C:
++		case 0x8D:
++			ep->type = SHARED;
++			rdr_log_dbg(rdr, D_EMM, "SHARED (part)");
++			// We need those packets to pass otherwise we would never
++			// be able to complete EMM reassembly
++			return 1;
++
++		case 0x8E:
++			ep->type = SHARED;
++			rdr_log_dbg(rdr, D_EMM, "SHARED");
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 3, 3);
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++int32_t emu_get_ird2_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	int32_t l = (ep->emm[3] & 0x07);
++	int32_t base = (ep->emm[3] >> 3);
++	char dumprdrserial[l * 3], dumpemmserial[l * 3];
++
++	switch (l)
++	{
++		case 0:
++			// global emm, 0 bytes addressed
++			ep->type = GLOBAL;
++			rdr_log_dbg(rdr, D_EMM, "GLOBAL base = %02x", base);
++			return 1;
++
++		case 2:
++			// shared emm, 2 bytes addressed
++			ep->type = SHARED;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, l);
++			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
++			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
++			rdr_log_dbg_sensitive(rdr, D_EMM, "SHARED l = %d ep = {%s} rdr = {%s} base = %02x",
++									l, dumpemmserial, dumprdrserial, base);
++			return 1;
++
++		case 3:
++			// unique emm, 3 bytes addressed
++			ep->type = UNIQUE;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, l);
++			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
++			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
++			rdr_log_dbg_sensitive(rdr, D_EMM, "UNIQUE l = %d ep = {%s} rdr = {%s} base = %02x",
++									l, dumpemmserial, dumprdrserial, base);
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++int32_t emu_get_pvu_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	if (ep->emm[0] == 0x82)
++	{
++		ep->type = UNIQUE;
++		memset(ep->hexserial, 0, 8);
++		memcpy(ep->hexserial, ep->emm + 12, 4);
++	}
++	else
++	{
++		ep->type = UNKNOWN;
++		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++	}
++	return 1;
++}
++
++int32_t emu_get_tan_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	if (ep->emm[0] == 0x82 || ep->emm[0] == 0x83)
++	{
++		ep->type = GLOBAL;
++	}
++	else
++	{
++		ep->type = UNKNOWN;
++		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++	}
++	return 1;
++}
++
++int32_t emu_get_biss_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	switch (ep->emm[0])
++	{
++		case 0x81: // Spec say this is for EMM, but oscam (and all other crypto systems) use it for ECM
++		case 0x82:
++		case 0x83:
++		case 0x84:
++		case 0x85:
++		case 0x86:
++		case 0x87:
++		case 0x88:
++		case 0x89:
++		case 0x8A:
++		case 0x8B:
++		case 0x8C:
++		case 0x8D:
++		case 0x8E:
++		case 0x8F:
++			ep->type = GLOBAL;
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++static int32_t emu_get_emm_type(struct emm_packet_t *ep, struct s_reader *rdr)
++{
++	uint16_t caid = b2i(2, ep->caid);
++
++	if (caid_is_viaccess(caid))     return emu_get_via3_emm_type(ep, rdr);
++	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_type(ep, rdr);
++	if (caid_is_powervu(caid))      return emu_get_pvu_emm_type(ep, rdr);
++	if (caid_is_director(caid))     return emu_get_tan_emm_type(ep, rdr);
++	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_type(ep, rdr);
++
++	return CS_ERROR;
++}
++
++FILTER *get_emu_prids_for_caid(struct s_reader *rdr, uint16_t caid)
++{
++	int32_t i;
++
++	for (i = 0; i < rdr->emu_auproviders.nfilts; i++)
++	{
++		if (caid == rdr->emu_auproviders.filts[i].caid)
++		{
++			return &rdr->emu_auproviders.filts[i];
++		}
++	}
++
++	return NULL;
++}
++
++static int32_t emu_get_via3_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 1;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x8A;
++		filters[idx].mask[0]   = 0xFE;
++		filters[idx].filter[3] = 0x80;
++		filters[idx].mask[3]   = 0x80;
++		idx++;
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_ird2_emm_filter(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t caid, uint32_t UNUSED(provid))
++{
++	uint8_t hexserial[3], prid[4];
++	FILTER *emu_provids;
++	int8_t have_provid = 0, have_serial = 0;
++	int32_t i;
++
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	if(irdeto2_get_hexserial(caid, hexserial))
++	{
++		have_serial = 1;
++	}
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	emu_provids = get_emu_prids_for_caid(rdr, caid);
++	if (emu_provids != NULL && emu_provids->nprids > 0)
++	{
++		have_provid = 1;
++	}
++
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = have_serial + (2 * (have_provid ? emu_provids->nprids : 0));
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		unsigned int idx = 0;
++
++		if (have_serial)
++		{
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFB;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], hexserial, 3);
++			memset(&filters[idx].mask[2], 0xFF, 3);
++			idx++;
++		}
++
++		for (i = 0; have_provid && i < emu_provids->nprids; i++)
++		{
++			i2b_buf(4, emu_provids->prids[i], prid);
++
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFB;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], &prid[1], 3);
++			memset(&filters[idx].mask[2], 0xFF, 3);
++			idx++;
++
++			filters[idx].type = EMM_SHARED;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFA;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], &prid[1], 2);
++			memset(&filters[idx].mask[2], 0xFF, 2);
++			idx++;
++		}
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_pvu_emm_filter(struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
++										uint16_t caid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
++{
++	uint8_t hexserials[32][4];
++	uint32_t i, count = 0;
++
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	count = powervu_get_hexserials_new(hexserials, 32, caid, tsid, onid, ens);
++	if (count == 0)
++	{
++		count = powervu_get_hexserials(hexserials, 32, srvid);
++		if (count == 0)
++		{
++			SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++			return CS_ERROR;
++		}
++	}
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = count;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		for (i = 0; i < count; i++)
++		{
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled    = 1;
++			filters[idx].filter[0]  = 0x82;
++			filters[idx].filter[10] = hexserials[i][0];
++			filters[idx].filter[11] = hexserials[i][1];
++			filters[idx].filter[12] = hexserials[i][2];
++			filters[idx].filter[13] = hexserials[i][3];
++			filters[idx].mask[0]    = 0xFF;
++			filters[idx].mask[10]   = 0xFF;
++			filters[idx].mask[11]   = 0xFF;
++			filters[idx].mask[12]   = 0xFF;
++			filters[idx].mask[13]   = 0xFF;
++			idx++;
++		}
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_tan_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 2;
++		uint8_t buf[8];
++
++		if (!emu_find_key('T', 0x40, 0, "MK", buf, 8, 0, 0, 0, NULL) &&
++			!emu_find_key('T', 0x40, 0, "MK01", buf, 8, 0, 0, 0, NULL))
++		{
++			return CS_ERROR;
++		}
++
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x82;
++		filters[idx].mask[0]   = 0xFF;
++		idx++;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x83;
++		filters[idx].mask[0]   = 0xFF;
++		idx++;
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_biss_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 15;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++		uint8_t i;
++
++		for (i = 0; i < max_filter_count; i++)
++		{
++			filters[idx].type = EMM_GLOBAL;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x81 + i; // What about table 0x81?
++			filters[idx].mask[0]   = 0xFF;
++			idx++;
++
++			*filter_count = idx;
++		}
++	}
++	return CS_OK;
++}
++
++static int32_t emu_get_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **UNUSED(emm_filters), unsigned int *UNUSED(filter_count))
++{
++	return CS_ERROR;
++}
++
++static int32_t emu_get_emm_filter_adv(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
++										uint16_t caid, uint32_t provid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
++{
++	if (caid_is_viaccess(caid))     return emu_get_via3_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_powervu(caid))      return emu_get_pvu_emm_filter(emm_filters, filter_count, caid, srvid, tsid, onid, ens);
++	if (caid_is_director(caid))     return emu_get_tan_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++
++	return CS_ERROR;
++}
++
++const struct s_cardsystem reader_emu =
++{
++	.desc = "emu",
++	.caids = (uint16_t[]){ 0x05, 0x06, 0x0D, 0x0E, 0x10, 0x18, 0x26, 0 },
++	.do_ecm = emu_do_ecm,
++	.do_emm = emu_do_emm,
++	.card_info = emu_card_info,
++	//.card_init = emu_card_init, // apparently this is not needed at all
++	.get_emm_type = emu_get_emm_type,
++	.get_emm_filter = emu_get_emm_filter, // needed to pass checks
++	.get_emm_filter_adv = emu_get_emm_filter_adv,
++};
++
++/*
++ * Create the Emu virtual "device" part. This is of type s_cardreader.
++ * Similar structures are found in the csctapi (Card System Card Terminal API)
++ * folder for every IFD (InterFace Device), aka smart card reader.
++ * Since we have no hardware to initialize, we start our Stream Relay server
++ * with the emu_reader_init() function.
++ * At Emu shutdown, we remove keys from memory with the emu_close() function.
++*/
++
++#define CR_OK    0
++#define CR_ERROR 1
++
++static int32_t emu_reader_init(struct s_reader *UNUSED(reader))
++{
++	int32_t i;
++	char authtmp[128];
++
++	if (cfg.emu_stream_relay_enabled && (stream_server_thread_init == 0))
++	{
++		stream_server_thread_init = 1;
++		SAFE_MUTEX_INIT(&emu_fixed_key_srvid_mutex, NULL);
++
++		for (i = 0; i < EMU_STREAM_SERVER_MAX_CONNECTIONS; i++)
++		{
++			SAFE_MUTEX_INIT(&emu_fixed_key_data_mutex[i], NULL);
++			ll_emu_stream_delayed_keys[i] = ll_create("ll_emu_stream_delayed_keys");
++			memset(&emu_fixed_key_data[i], 0, sizeof(emu_stream_client_key_data));
++		}
++
++		start_thread("stream_key_delayer", stream_key_delayer, NULL, NULL, 1, 1);
++		cs_log("Stream key delayer initialized");
++
++		cs_strncpy(emu_stream_source_host, cfg.emu_stream_source_host, sizeof(emu_stream_source_host));
++		emu_stream_source_port = cfg.emu_stream_source_port;
++		emu_stream_relay_port = cfg.emu_stream_relay_port;
++		emu_stream_emm_enabled = cfg.emu_stream_emm_enabled;
++
++		if (cfg.emu_stream_source_auth_user && cfg.emu_stream_source_auth_password)
++		{
++			snprintf(authtmp, sizeof(authtmp), "%s:%s", cfg.emu_stream_source_auth_user, cfg.emu_stream_source_auth_password);
++			b64encode(authtmp, strlen(authtmp), &emu_stream_source_auth);
++		}
++		else
++		{
++			NULLFREE(emu_stream_source_auth);
++		}
++
++		start_thread("stream_server", stream_server, NULL, NULL, 1, 1);
++		cs_log("Stream relay server initialized");
++	}
++
++	// Initialize mutex for exclusive access to key database and key file
++	if (!emu_key_data_mutex_init)
++	{
++		SAFE_MUTEX_INIT(&emu_key_data_mutex, NULL);
++		emu_key_data_mutex_init = 1;
++	}
++
++	return CR_OK;
++}
++
++static int32_t emu_close(struct s_reader *UNUSED(reader))
++{
++	cs_log("Reader is shutting down");
++
++	// Delete keys from Emu's memory
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	emu_clear_keydata();
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	return CR_OK;
++}
++
++static int32_t emu_get_status(struct s_reader *UNUSED(reader), int32_t *in) { *in = 1; return CR_OK; }
++static int32_t emu_activate(struct s_reader *UNUSED(reader), struct s_ATR *UNUSED(atr)) { return CR_OK; }
++static int32_t emu_transmit(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(expectedlen), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
++static int32_t emu_receive(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
++static int32_t emu_write_settings(struct s_reader *UNUSED(reader), struct s_cardreader_settings *UNUSED(s)) { return CR_OK; }
++static int32_t emu_card_write(struct s_reader *UNUSED(pcsc_reader), const uint8_t *UNUSED(buf), uint8_t *UNUSED(cta_res), uint16_t *UNUSED(cta_lr), int32_t UNUSED(l)) { return CR_OK; }
++static int32_t emu_set_protocol(struct s_reader *UNUSED(rdr), uint8_t *UNUSED(params), uint32_t *UNUSED(length), uint32_t UNUSED(len_request)) { return CR_OK; }
++
++const struct s_cardreader cardreader_emu =
++{
++	.desc                   = "emu",
++	.typ                    = R_EMU,
++	.skip_extra_atr_parsing = 1,
++	.reader_init            = emu_reader_init,
++	.get_status             = emu_get_status,
++	.activate               = emu_activate,
++	.transmit               = emu_transmit,
++	.receive                = emu_receive,
++	.close                  = emu_close,
++	.write_settings         = emu_write_settings,
++	.card_write             = emu_card_write,
++	.set_protocol           = emu_set_protocol,
++};
++
++void add_emu_reader(void)
++{
++	// This function is called inside oscam.c and creates an emu [reader] with default
++	// settings in oscam.server file. If an emu [reader] already exists, it uses that.
++
++	LL_ITER itr;
++	struct s_reader *rdr;
++	int8_t haveEmuReader = 0;
++	char emuName[] = "emulator";
++	char *ctab, *ftab, *emu_auproviders, *disablecrccws_only_for;
++
++	// Check if emu [reader] entry already exists in oscam.server file and get it
++	itr = ll_iter_create(configured_readers);
++	while ((rdr = ll_iter_next(&itr)))
++	{
++		if (rdr->typ == R_EMU)
++		{
++			haveEmuReader = 1;
++			break;
++		}
++	}
++
++	rdr = NULL;
++
++	// If there's no emu [reader] in oscam.server, create one with default settings
++	if (!haveEmuReader)
++	{
++		if (!cs_malloc(&rdr, sizeof(struct s_reader)))
++		{
++			return;
++		}
++
++		reader_set_defaults(rdr);
++
++		rdr->enable = 1;
++		rdr->typ = R_EMU;
++		cs_strncpy(rdr->label, emuName, sizeof(emuName));
++		cs_strncpy(rdr->device, emuName, sizeof(emuName));
++
++		// CAIDs
++		ctab = strdup("0500,0604,0E00,1010,1801,2600,2602,2610");
++		chk_caidtab(ctab, &rdr->ctab);
++		NULLFREE(ctab);
++
++		// Idents
++		ftab = strdup("0500:000000,007400,007800,021110,023800;"
++					  "0604:000000;"
++					  "0E00:000000;"
++					  "1010:000000;"
++					  "1801:000000,001101,002111,007301;"
++					  "2600:000000;"
++					  "2602:000000;"
++					  "2610:000000;"
++					 );
++		chk_ftab(ftab, &rdr->ftab);
++		NULLFREE(ftab);
++
++		// AU providers
++		emu_auproviders = strdup("0604:010200;0E00:000000;1010:000000;2610:000000;");
++		chk_ftab(emu_auproviders, &rdr->emu_auproviders);
++		NULLFREE(emu_auproviders);
++
++		// EMM cache
++		rdr->cachemm = 2;
++		rdr->rewritemm = 1;
++		rdr->logemm = 2;
++		rdr->deviceemm = 1;
++
++		// User group
++		rdr->grp = 0x1ULL;
++
++		// Add the "device" part to our emu reader
++		rdr->crdr = &cardreader_emu;
++
++		// Disable CW checksum test for PowerVu
++		disablecrccws_only_for = strdup("0E00:000000");
++		chk_ftab(disablecrccws_only_for, &rdr->disablecrccws_only_for);
++		NULLFREE(disablecrccws_only_for);
++
++		reader_fixups_fn(rdr);
++		ll_append(configured_readers, rdr);
++	}
++
++	// Set DVB Api delayer option
++#ifdef HAVE_DVBAPI
++	if (cfg.dvbapi_enabled && cfg.dvbapi_delayer < 60)
++	{
++		cfg.dvbapi_delayer = 60;
++	}
++#endif
++
++	cs_log("OSCam-Emu version %d", EMU_VERSION);
++}
++
++#endif // WITH_EMU
+--- oscam-svn/module-emulator-cryptoworks.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-cryptoworks.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,688 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -1957,10 +2837,8 @@ Index: module-emulator-cryptoworks.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-cryptoworks.h
-===================================================================
---- module-emulator-cryptoworks.h	(nonexistent)
-+++ module-emulator-cryptoworks.h	(working copy)
+--- oscam-svn/module-emulator-cryptoworks.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-cryptoworks.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_CRYPTOWORKS_H
 +#define MODULE_EMULATOR_CRYPTOWORKS_H
@@ -1972,10 +2850,8 @@ Index: module-emulator-cryptoworks.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_CRYPTOWORKS_H
-Index: module-emulator-director.c
-===================================================================
---- module-emulator-director.c	(nonexistent)
-+++ module-emulator-director.c	(working copy)
+--- oscam-svn/module-emulator-director.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-director.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,642 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -2619,10 +3495,8 @@ Index: module-emulator-director.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-director.h
-===================================================================
---- module-emulator-director.h	(nonexistent)
-+++ module-emulator-director.h	(working copy)
+--- oscam-svn/module-emulator-director.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-director.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_DIRECTOR_H
 +#define MODULE_EMULATOR_DIRECTOR_H
@@ -2635,10 +3509,8 @@ Index: module-emulator-director.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_DIRECTOR_H
-Index: module-emulator-irdeto.c
-===================================================================
---- module-emulator-irdeto.c	(nonexistent)
-+++ module-emulator-irdeto.c	(working copy)
+--- oscam-svn/module-emulator-irdeto.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-irdeto.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,602 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -3242,10 +4114,8 @@ Index: module-emulator-irdeto.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-irdeto.h
-===================================================================
---- module-emulator-irdeto.h	(nonexistent)
-+++ module-emulator-irdeto.h	(working copy)
+--- oscam-svn/module-emulator-irdeto.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-irdeto.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,15 @@
 +#ifndef MODULE_EMULATOR_IRDETO_H
 +#define MODULE_EMULATOR_IRDETO_H
@@ -3262,10 +4132,8 @@ Index: module-emulator-irdeto.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_IRDETO_H
-Index: module-emulator-nagravision.c
-===================================================================
---- module-emulator-nagravision.c	(nonexistent)
-+++ module-emulator-nagravision.c	(working copy)
+--- oscam-svn/module-emulator-nagravision.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-nagravision.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,376 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -3643,10 +4511,8 @@ Index: module-emulator-nagravision.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-nagravision.h
-===================================================================
---- module-emulator-nagravision.h	(nonexistent)
-+++ module-emulator-nagravision.h	(working copy)
+--- oscam-svn/module-emulator-nagravision.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-nagravision.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_NAGRAVISION_H
 +#define MODULE_EMULATOR_NAGRAVISION_H
@@ -3658,10 +4524,8 @@ Index: module-emulator-nagravision.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_NAGRAVISION_H
-Index: module-emulator-osemu.c
-===================================================================
---- module-emulator-osemu.c	(nonexistent)
-+++ module-emulator-osemu.c	(working copy)
+--- oscam-svn/module-emulator-osemu.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-osemu.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,972 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -4635,10 +5499,8 @@ Index: module-emulator-osemu.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-osemu.h
-===================================================================
---- module-emulator-osemu.h	(nonexistent)
-+++ module-emulator-osemu.h	(working copy)
+--- oscam-svn/module-emulator-osemu.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-osemu.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,95 @@
 +#ifndef MODULE_EMULATOR_OSEMU_H_
 +#define MODULE_EMULATOR_OSEMU_H_
@@ -4735,10 +5597,8 @@ Index: module-emulator-osemu.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_H_
-Index: module-emulator-powervu.c
-===================================================================
---- module-emulator-powervu.c	(nonexistent)
-+++ module-emulator-powervu.c	(working copy)
+--- oscam-svn/module-emulator-powervu.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-powervu.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,2691 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -7431,10 +8291,8 @@ Index: module-emulator-powervu.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-powervu.h
-===================================================================
---- module-emulator-powervu.h	(nonexistent)
-+++ module-emulator-powervu.h	(working copy)
+--- oscam-svn/module-emulator-powervu.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-powervu.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,59 @@
 +#ifndef MODULE_EMULATOR_POWERVU_H
 +#define MODULE_EMULATOR_POWERVU_H
@@ -7495,10 +8353,8 @@ Index: module-emulator-powervu.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_POWERVU_H
-Index: module-emulator-streamserver.c
-===================================================================
---- module-emulator-streamserver.c	(nonexistent)
-+++ module-emulator-streamserver.c	(working copy)
+--- oscam-svn/module-emulator-streamserver.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-streamserver.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,1802 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -9302,10 +10158,8 @@ Index: module-emulator-streamserver.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-streamserver.h
-===================================================================
---- module-emulator-streamserver.h	(nonexistent)
-+++ module-emulator-streamserver.h	(working copy)
+--- oscam-svn/module-emulator-streamserver.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-streamserver.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,90 @@
 +#ifndef MODULE_EMULATOR_STREAMSERVER_H_
 +#define MODULE_EMULATOR_STREAMSERVER_H_
@@ -9397,10 +10251,8 @@ Index: module-emulator-streamserver.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_STREAMSERVER_H_
-Index: module-emulator-viaccess.c
-===================================================================
---- module-emulator-viaccess.c	(nonexistent)
-+++ module-emulator-viaccess.c	(working copy)
+--- oscam-svn/module-emulator-viaccess.c	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-viaccess.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,1183 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -10585,10 +11437,8 @@ Index: module-emulator-viaccess.c
 +}
 +
 +#endif // WITH_EMU
-Index: module-emulator-viaccess.h
-===================================================================
---- module-emulator-viaccess.h	(nonexistent)
-+++ module-emulator-viaccess.h	(working copy)
+--- oscam-svn/module-emulator-viaccess.h	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/module-emulator-viaccess.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_VIACCESS_H
 +#define MODULE_EMULATOR_VIACCESS_H
@@ -10601,919 +11451,8 @@ Index: module-emulator-viaccess.h
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_VIACCESS_H
-Index: module-emulator.c
-===================================================================
---- module-emulator.c	(nonexistent)
-+++ module-emulator.c	(working copy)
-@@ -0,0 +1,904 @@
-+#define MODULE_LOG_PREFIX "emu"
-+
-+#include "globals.h"
-+
-+#ifdef WITH_EMU
-+
-+#include "module-emulator-osemu.h"
-+#include "module-emulator-streamserver.h"
-+#include "module-emulator-biss.h"
-+#include "module-emulator-irdeto.h"
-+#include "module-emulator-powervu.h"
-+#include "oscam-conf-chk.h"
-+#include "oscam-config.h"
-+#include "oscam-reader.h"
-+#include "oscam-string.h"
-+
-+/*
-+ * Readers in OSCam consist of 2 basic parts.
-+ * The hardware or the device part. This is where physical smart cards are inserted
-+ * and made available to OSCam.
-+ * The software or the emulation part. This is where the actual card reading is done,
-+ * including ecm and emm processing (i.e emulation of the various cryptosystems).
-+ * In the Emu reader, the device part has no meaning, but we have to create it in
-+ * order to be compatible with OSCam's reader structure.
-+*/
-+
-+/*
-+ * Create the Emu "emulation" part. This is of type s_cardsystem.
-+ * Similar structures are found in the main sources folder (files reader-xxxxxx.c)
-+ * for every cryptosystem supported by OSCam.
-+ * Here we read keys from our virtual card (aka the SoftCam.Key file) and we inform
-+ * OSCam about them. This is done with the emu_card_info() function. Keep in mind
-+ * that Emu holds all its keys to separate structures for faster access.
-+ * In addition, ECM and EMM requests are processed here, with the emu_do_ecm() and
-+ * emu_do_emm() functions.
-+*/
-+
-+#define CS_OK    1
-+#define CS_ERROR 0
-+
-+extern char cs_confdir[128];
-+static int8_t emu_key_data_mutex_init = 0;
-+pthread_mutex_t emu_key_data_mutex;
-+
-+static void set_hexserial_to_version(struct s_reader *rdr)
-+{
-+	char cVersion[32];
-+	uint32_t version = EMU_VERSION;
-+	uint8_t hversion[2];
-+	memset(hversion, 0, 2);
-+	snprintf(cVersion, sizeof(cVersion), "%04d", version);
-+	char_to_bin(hversion, cVersion, 4);
-+	rdr->hexserial[3] = hversion[0];
-+	rdr->hexserial[4] = hversion[1];
-+}
-+
-+static void set_prids(struct s_reader *rdr)
-+{
-+	int32_t i, j;
-+
-+	rdr->nprov = 0;
-+
-+	for (i = 0; (i < rdr->emu_auproviders.nfilts) && (rdr->nprov < CS_MAXPROV); i++)
-+	{
-+		for (j = 0; (j < rdr->emu_auproviders.filts[i].nprids) && (rdr->nprov < CS_MAXPROV); j++)
-+		{
-+			i2b_buf(4, rdr->emu_auproviders.filts[i].prids[j], rdr->prid[i]);
-+			rdr->nprov++;
-+		}
-+	}
-+}
-+
-+static void emu_add_entitlement(struct s_reader *rdr, uint16_t caid, uint32_t provid, uint8_t *key, char *keyName, uint32_t keyLength, uint8_t isData)
-+{
-+	if (!rdr->ll_entitlements)
-+	{
-+		rdr->ll_entitlements = ll_create("ll_entitlements");
-+	}
-+
-+	S_ENTITLEMENT *item;
-+	if (cs_malloc(&item, sizeof(S_ENTITLEMENT)))
-+	{
-+		// fill item
-+		item->caid = caid;
-+		item->provid = provid;
-+		item->id = 0;
-+		item->class = 0;
-+		item->start = 0;
-+		item->end = 2147472000;
-+		item->type = 0;
-+		item->isKey = 1;
-+		memcpy(item->name, keyName, 8);
-+		item->key = key;
-+		item->keyLength = keyLength;
-+		item->isData = isData;
-+
-+		// add item
-+		ll_append(rdr->ll_entitlements, item);
-+	}
-+}
-+
-+static void refresh_entitlements(struct s_reader *rdr)
-+{
-+	uint32_t i;
-+	uint16_t caid;
-+	KeyData *tmpKeyData;
-+	LL_ITER itr;
-+	biss2_rsa_key_t *item;
-+
-+	cs_clear_entitlement(rdr);
-+
-+	for (i = 0; i < StreamKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, b2i(2, StreamKeys.EmuKeys[i].key), StreamKeys.EmuKeys[i].provider, StreamKeys.EmuKeys[i].key,
-+							StreamKeys.EmuKeys[i].keyName, StreamKeys.EmuKeys[i].keyLength, 1);
-+	}
-+
-+	for (i = 0; i < ViKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x0500, ViKeys.EmuKeys[i].provider, ViKeys.EmuKeys[i].key,
-+							ViKeys.EmuKeys[i].keyName, ViKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < IrdetoKeys.keyCount; i++)
-+	{
-+		tmpKeyData = &IrdetoKeys.EmuKeys[i];
-+		do
-+		{
-+			emu_add_entitlement(rdr, tmpKeyData->provider >> 8, tmpKeyData->provider & 0xFF,
-+								tmpKeyData->key, tmpKeyData->keyName, tmpKeyData->keyLength, 0);
-+
-+			tmpKeyData = tmpKeyData->nextKey;
-+		}
-+		while (tmpKeyData != NULL);
-+	}
-+
-+	for (i = 0; i < CwKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, CwKeys.EmuKeys[i].provider >> 8, CwKeys.EmuKeys[i].provider & 0xFF,
-+							CwKeys.EmuKeys[i].key, CwKeys.EmuKeys[i].keyName, CwKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < PowervuKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x0E00, PowervuKeys.EmuKeys[i].provider, PowervuKeys.EmuKeys[i].key,
-+							PowervuKeys.EmuKeys[i].keyName, PowervuKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < TandbergKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x1010, TandbergKeys.EmuKeys[i].provider, TandbergKeys.EmuKeys[i].key,
-+							TandbergKeys.EmuKeys[i].keyName, TandbergKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < NagraKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x1801, NagraKeys.EmuKeys[i].provider, NagraKeys.EmuKeys[i].key,
-+							NagraKeys.EmuKeys[i].keyName, NagraKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// Session words for BISS1 mode 1/E (caid 2600) and BISS2 mode 1/E (caid 2602)
-+	for (i = 0; i < BissSWs.keyCount; i++)
-+	{
-+		caid = (BissSWs.EmuKeys[i].keyLength == 8) ? 0x2600 : 0x2602;
-+		emu_add_entitlement(rdr, caid, BissSWs.EmuKeys[i].provider, BissSWs.EmuKeys[i].key,
-+							BissSWs.EmuKeys[i].keyName, BissSWs.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// Session keys (ECM keys) for BISS2 mode CA
-+	for (i = 0; i < Biss2Keys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x2610, Biss2Keys.EmuKeys[i].provider, Biss2Keys.EmuKeys[i].key,
-+							Biss2Keys.EmuKeys[i].keyName, Biss2Keys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// RSA keys (EMM keys) for BISS2 mode CA
-+	itr = ll_iter_create(rdr->ll_biss2_rsa_keys);
-+	while ((item = ll_iter_next(&itr)))
-+	{
-+		emu_add_entitlement(rdr, 0x2610, 0, item->ekid, "RSAPRI", 8, 0);
-+	}
-+}
-+
-+static int32_t emu_do_ecm(struct s_reader *rdr, const ECM_REQUEST *er, struct s_ecm_answer *ea)
-+{
-+	if (!emu_process_ecm(rdr, er, ea->cw, &ea->cw_ex))
-+	{
-+		return CS_OK;
-+	}
-+
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_do_emm(struct s_reader *rdr, EMM_PACKET *emm)
-+{
-+	uint32_t keysAdded = 0;
-+
-+	if (emm->emmlen < 3)
-+	{
-+		return CS_ERROR;
-+	}
-+
-+	if (SCT_LEN(emm->emm) > emm->emmlen)
-+	{
-+		return CS_ERROR;
-+	}
-+
-+	if (!emu_process_emm(rdr, b2i(2, emm->caid), emm->emm, &keysAdded))
-+	{
-+		if (keysAdded > 0)
-+		{
-+			refresh_entitlements(rdr);
-+		}
-+
-+		return CS_OK;
-+	}
-+
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_card_info(struct s_reader *rdr)
-+{
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+
-+	// Delete keys from Emu's memory
-+	emu_clear_keydata();
-+
-+	// Delete BISS2 mode CA RSA keys
-+	ll_destroy_data(&rdr->ll_biss2_rsa_keys);
-+
-+	// Read keys built in the OSCam-Emu binary
-+	emu_read_keymemory(rdr);
-+
-+	// Read keys from SoftCam.Key file
-+	emu_set_keyfile_path(cs_confdir);
-+
-+	if (!emu_read_keyfile(rdr, cs_confdir))
-+	{
-+		if (emu_read_keyfile(rdr, "/var/keys/"))
-+		{
-+			emu_set_keyfile_path("/var/keys/");
-+		}
-+	}
-+
-+	// Read BISS2 mode CA RSA keys from PEM files
-+	biss_read_pem(rdr, BISS2_MAX_RSA_KEYS);
-+
-+	cs_log("Total keys in memory: W:%d V:%d N:%d I:%d F:%d G:%d P:%d T:%d A:%d",
-+			CwKeys.keyCount, ViKeys.keyCount, NagraKeys.keyCount, IrdetoKeys.keyCount,
-+			BissSWs.keyCount, Biss2Keys.keyCount, PowervuKeys.keyCount, TandbergKeys.keyCount,
-+			StreamKeys.keyCount);
-+
-+	// Inform OSCam about all available keys.
-+	// This is used for listing the "entitlements" in the webif's reader page.
-+	refresh_entitlements(rdr);
-+
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	set_prids(rdr);
-+
-+	set_hexserial_to_version(rdr);
-+
-+	return CS_OK;
-+}
-+
-+/*
-+static int32_t emu_card_init(struct s_reader *UNUSED(rdr), struct s_ATR *UNUSED(atr))
-+{
-+	return CS_ERROR;
-+}
-+*/
-+
-+int32_t emu_get_via3_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	uint32_t provid = 0;
-+
-+	if(ep->emm[3] == 0x90 && ep->emm[4] == 0x03)
-+	{
-+		provid = b2i(3, ep->emm + 5);
-+		provid &= 0xFFFFF0;
-+		i2b_buf(4, provid, ep->provid);
-+	}
-+
-+	switch (ep->emm[0])
-+	{
-+		case 0x88:
-+			ep->type = UNIQUE;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, 4);
-+			rdr_log_dbg(rdr, D_EMM, "UNIQUE");
-+			return 1;
-+
-+		case 0x8A:
-+		case 0x8B:
-+			ep->type = GLOBAL;
-+			rdr_log_dbg(rdr, D_EMM, "GLOBAL");
-+			return 1;
-+
-+		case 0x8C:
-+		case 0x8D:
-+			ep->type = SHARED;
-+			rdr_log_dbg(rdr, D_EMM, "SHARED (part)");
-+			// We need those packets to pass otherwise we would never
-+			// be able to complete EMM reassembly
-+			return 1;
-+
-+		case 0x8E:
-+			ep->type = SHARED;
-+			rdr_log_dbg(rdr, D_EMM, "SHARED");
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 3, 3);
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+int32_t emu_get_ird2_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	int32_t l = (ep->emm[3] & 0x07);
-+	int32_t base = (ep->emm[3] >> 3);
-+	char dumprdrserial[l * 3], dumpemmserial[l * 3];
-+
-+	switch (l)
-+	{
-+		case 0:
-+			// global emm, 0 bytes addressed
-+			ep->type = GLOBAL;
-+			rdr_log_dbg(rdr, D_EMM, "GLOBAL base = %02x", base);
-+			return 1;
-+
-+		case 2:
-+			// shared emm, 2 bytes addressed
-+			ep->type = SHARED;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, l);
-+			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
-+			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
-+			rdr_log_dbg_sensitive(rdr, D_EMM, "SHARED l = %d ep = {%s} rdr = {%s} base = %02x",
-+									l, dumpemmserial, dumprdrserial, base);
-+			return 1;
-+
-+		case 3:
-+			// unique emm, 3 bytes addressed
-+			ep->type = UNIQUE;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, l);
-+			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
-+			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
-+			rdr_log_dbg_sensitive(rdr, D_EMM, "UNIQUE l = %d ep = {%s} rdr = {%s} base = %02x",
-+									l, dumpemmserial, dumprdrserial, base);
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+int32_t emu_get_pvu_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	if (ep->emm[0] == 0x82)
-+	{
-+		ep->type = UNIQUE;
-+		memset(ep->hexserial, 0, 8);
-+		memcpy(ep->hexserial, ep->emm + 12, 4);
-+	}
-+	else
-+	{
-+		ep->type = UNKNOWN;
-+		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+	}
-+	return 1;
-+}
-+
-+int32_t emu_get_tan_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	if (ep->emm[0] == 0x82 || ep->emm[0] == 0x83)
-+	{
-+		ep->type = GLOBAL;
-+	}
-+	else
-+	{
-+		ep->type = UNKNOWN;
-+		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+	}
-+	return 1;
-+}
-+
-+int32_t emu_get_biss_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	switch (ep->emm[0])
-+	{
-+		case 0x81: // Spec say this is for EMM, but oscam (and all other crypto systems) use it for ECM
-+		case 0x82:
-+		case 0x83:
-+		case 0x84:
-+		case 0x85:
-+		case 0x86:
-+		case 0x87:
-+		case 0x88:
-+		case 0x89:
-+		case 0x8A:
-+		case 0x8B:
-+		case 0x8C:
-+		case 0x8D:
-+		case 0x8E:
-+		case 0x8F:
-+			ep->type = GLOBAL;
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+static int32_t emu_get_emm_type(struct emm_packet_t *ep, struct s_reader *rdr)
-+{
-+	uint16_t caid = b2i(2, ep->caid);
-+
-+	if (caid_is_viaccess(caid))     return emu_get_via3_emm_type(ep, rdr);
-+	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_type(ep, rdr);
-+	if (caid_is_powervu(caid))      return emu_get_pvu_emm_type(ep, rdr);
-+	if (caid_is_director(caid))     return emu_get_tan_emm_type(ep, rdr);
-+	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_type(ep, rdr);
-+
-+	return CS_ERROR;
-+}
-+
-+FILTER *get_emu_prids_for_caid(struct s_reader *rdr, uint16_t caid)
-+{
-+	int32_t i;
-+
-+	for (i = 0; i < rdr->emu_auproviders.nfilts; i++)
-+	{
-+		if (caid == rdr->emu_auproviders.filts[i].caid)
-+		{
-+			return &rdr->emu_auproviders.filts[i];
-+		}
-+	}
-+
-+	return NULL;
-+}
-+
-+static int32_t emu_get_via3_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 1;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x8A;
-+		filters[idx].mask[0]   = 0xFE;
-+		filters[idx].filter[3] = 0x80;
-+		filters[idx].mask[3]   = 0x80;
-+		idx++;
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_ird2_emm_filter(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t caid, uint32_t UNUSED(provid))
-+{
-+	uint8_t hexserial[3], prid[4];
-+	FILTER *emu_provids;
-+	int8_t have_provid = 0, have_serial = 0;
-+	int32_t i;
-+
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	if(irdeto2_get_hexserial(caid, hexserial))
-+	{
-+		have_serial = 1;
-+	}
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	emu_provids = get_emu_prids_for_caid(rdr, caid);
-+	if (emu_provids != NULL && emu_provids->nprids > 0)
-+	{
-+		have_provid = 1;
-+	}
-+
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = have_serial + (2 * (have_provid ? emu_provids->nprids : 0));
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		unsigned int idx = 0;
-+
-+		if (have_serial)
-+		{
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFB;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], hexserial, 3);
-+			memset(&filters[idx].mask[2], 0xFF, 3);
-+			idx++;
-+		}
-+
-+		for (i = 0; have_provid && i < emu_provids->nprids; i++)
-+		{
-+			i2b_buf(4, emu_provids->prids[i], prid);
-+
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFB;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], &prid[1], 3);
-+			memset(&filters[idx].mask[2], 0xFF, 3);
-+			idx++;
-+
-+			filters[idx].type = EMM_SHARED;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFA;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], &prid[1], 2);
-+			memset(&filters[idx].mask[2], 0xFF, 2);
-+			idx++;
-+		}
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_pvu_emm_filter(struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
-+										uint16_t caid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
-+{
-+	uint8_t hexserials[32][4];
-+	uint32_t i, count = 0;
-+
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	count = powervu_get_hexserials_new(hexserials, 32, caid, tsid, onid, ens);
-+	if (count == 0)
-+	{
-+		count = powervu_get_hexserials(hexserials, 32, srvid);
-+		if (count == 0)
-+		{
-+			SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+			return CS_ERROR;
-+		}
-+	}
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = count;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		for (i = 0; i < count; i++)
-+		{
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled    = 1;
-+			filters[idx].filter[0]  = 0x82;
-+			filters[idx].filter[10] = hexserials[i][0];
-+			filters[idx].filter[11] = hexserials[i][1];
-+			filters[idx].filter[12] = hexserials[i][2];
-+			filters[idx].filter[13] = hexserials[i][3];
-+			filters[idx].mask[0]    = 0xFF;
-+			filters[idx].mask[10]   = 0xFF;
-+			filters[idx].mask[11]   = 0xFF;
-+			filters[idx].mask[12]   = 0xFF;
-+			filters[idx].mask[13]   = 0xFF;
-+			idx++;
-+		}
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_tan_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 2;
-+		uint8_t buf[8];
-+
-+		if (!emu_find_key('T', 0x40, 0, "MK", buf, 8, 0, 0, 0, NULL) &&
-+			!emu_find_key('T', 0x40, 0, "MK01", buf, 8, 0, 0, 0, NULL))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x82;
-+		filters[idx].mask[0]   = 0xFF;
-+		idx++;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x83;
-+		filters[idx].mask[0]   = 0xFF;
-+		idx++;
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_biss_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 15;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+		uint8_t i;
-+
-+		for (i = 0; i < max_filter_count; i++)
-+		{
-+			filters[idx].type = EMM_GLOBAL;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x81 + i; // What about table 0x81?
-+			filters[idx].mask[0]   = 0xFF;
-+			idx++;
-+
-+			*filter_count = idx;
-+		}
-+	}
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **UNUSED(emm_filters), unsigned int *UNUSED(filter_count))
-+{
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_get_emm_filter_adv(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
-+										uint16_t caid, uint32_t provid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
-+{
-+	if (caid_is_viaccess(caid))     return emu_get_via3_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_powervu(caid))      return emu_get_pvu_emm_filter(emm_filters, filter_count, caid, srvid, tsid, onid, ens);
-+	if (caid_is_director(caid))     return emu_get_tan_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+
-+	return CS_ERROR;
-+}
-+
-+const struct s_cardsystem reader_emu =
-+{
-+	.desc = "emu",
-+	.caids = (uint16_t[]){ 0x05, 0x06, 0x0D, 0x0E, 0x10, 0x18, 0x26, 0 },
-+	.do_ecm = emu_do_ecm,
-+	.do_emm = emu_do_emm,
-+	.card_info = emu_card_info,
-+	//.card_init = emu_card_init, // apparently this is not needed at all
-+	.get_emm_type = emu_get_emm_type,
-+	.get_emm_filter = emu_get_emm_filter, // needed to pass checks
-+	.get_emm_filter_adv = emu_get_emm_filter_adv,
-+};
-+
-+/*
-+ * Create the Emu virtual "device" part. This is of type s_cardreader.
-+ * Similar structures are found in the csctapi (Card System Card Terminal API)
-+ * folder for every IFD (InterFace Device), aka smart card reader.
-+ * Since we have no hardware to initialize, we start our Stream Relay server
-+ * with the emu_reader_init() function.
-+ * At Emu shutdown, we remove keys from memory with the emu_close() function.
-+*/
-+
-+#define CR_OK    0
-+#define CR_ERROR 1
-+
-+static int32_t emu_reader_init(struct s_reader *UNUSED(reader))
-+{
-+	int32_t i;
-+	char authtmp[128];
-+
-+	if (cfg.emu_stream_relay_enabled && (stream_server_thread_init == 0))
-+	{
-+		stream_server_thread_init = 1;
-+		SAFE_MUTEX_INIT(&emu_fixed_key_srvid_mutex, NULL);
-+
-+		for (i = 0; i < EMU_STREAM_SERVER_MAX_CONNECTIONS; i++)
-+		{
-+			SAFE_MUTEX_INIT(&emu_fixed_key_data_mutex[i], NULL);
-+			ll_emu_stream_delayed_keys[i] = ll_create("ll_emu_stream_delayed_keys");
-+			memset(&emu_fixed_key_data[i], 0, sizeof(emu_stream_client_key_data));
-+		}
-+
-+		start_thread("stream_key_delayer", stream_key_delayer, NULL, NULL, 1, 1);
-+		cs_log("Stream key delayer initialized");
-+
-+		cs_strncpy(emu_stream_source_host, cfg.emu_stream_source_host, sizeof(emu_stream_source_host));
-+		emu_stream_source_port = cfg.emu_stream_source_port;
-+		emu_stream_relay_port = cfg.emu_stream_relay_port;
-+		emu_stream_emm_enabled = cfg.emu_stream_emm_enabled;
-+
-+		if (cfg.emu_stream_source_auth_user && cfg.emu_stream_source_auth_password)
-+		{
-+			snprintf(authtmp, sizeof(authtmp), "%s:%s", cfg.emu_stream_source_auth_user, cfg.emu_stream_source_auth_password);
-+			b64encode(authtmp, strlen(authtmp), &emu_stream_source_auth);
-+		}
-+		else
-+		{
-+			NULLFREE(emu_stream_source_auth);
-+		}
-+
-+		start_thread("stream_server", stream_server, NULL, NULL, 1, 1);
-+		cs_log("Stream relay server initialized");
-+	}
-+
-+	// Initialize mutex for exclusive access to key database and key file
-+	if (!emu_key_data_mutex_init)
-+	{
-+		SAFE_MUTEX_INIT(&emu_key_data_mutex, NULL);
-+		emu_key_data_mutex_init = 1;
-+	}
-+
-+	return CR_OK;
-+}
-+
-+static int32_t emu_close(struct s_reader *UNUSED(reader))
-+{
-+	cs_log("Reader is shutting down");
-+
-+	// Delete keys from Emu's memory
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	emu_clear_keydata();
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	return CR_OK;
-+}
-+
-+static int32_t emu_get_status(struct s_reader *UNUSED(reader), int32_t *in) { *in = 1; return CR_OK; }
-+static int32_t emu_activate(struct s_reader *UNUSED(reader), struct s_ATR *UNUSED(atr)) { return CR_OK; }
-+static int32_t emu_transmit(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(expectedlen), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
-+static int32_t emu_receive(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
-+static int32_t emu_write_settings(struct s_reader *UNUSED(reader), struct s_cardreader_settings *UNUSED(s)) { return CR_OK; }
-+static int32_t emu_card_write(struct s_reader *UNUSED(pcsc_reader), const uint8_t *UNUSED(buf), uint8_t *UNUSED(cta_res), uint16_t *UNUSED(cta_lr), int32_t UNUSED(l)) { return CR_OK; }
-+static int32_t emu_set_protocol(struct s_reader *UNUSED(rdr), uint8_t *UNUSED(params), uint32_t *UNUSED(length), uint32_t UNUSED(len_request)) { return CR_OK; }
-+
-+const struct s_cardreader cardreader_emu =
-+{
-+	.desc                   = "emu",
-+	.typ                    = R_EMU,
-+	.skip_extra_atr_parsing = 1,
-+	.reader_init            = emu_reader_init,
-+	.get_status             = emu_get_status,
-+	.activate               = emu_activate,
-+	.transmit               = emu_transmit,
-+	.receive                = emu_receive,
-+	.close                  = emu_close,
-+	.write_settings         = emu_write_settings,
-+	.card_write             = emu_card_write,
-+	.set_protocol           = emu_set_protocol,
-+};
-+
-+void add_emu_reader(void)
-+{
-+	// This function is called inside oscam.c and creates an emu [reader] with default
-+	// settings in oscam.server file. If an emu [reader] already exists, it uses that.
-+
-+	LL_ITER itr;
-+	struct s_reader *rdr;
-+	int8_t haveEmuReader = 0;
-+	char emuName[] = "emulator";
-+	char *ctab, *ftab, *emu_auproviders, *disablecrccws_only_for;
-+
-+	// Check if emu [reader] entry already exists in oscam.server file and get it
-+	itr = ll_iter_create(configured_readers);
-+	while ((rdr = ll_iter_next(&itr)))
-+	{
-+		if (rdr->typ == R_EMU)
-+		{
-+			haveEmuReader = 1;
-+			break;
-+		}
-+	}
-+
-+	rdr = NULL;
-+
-+	// If there's no emu [reader] in oscam.server, create one with default settings
-+	if (!haveEmuReader)
-+	{
-+		if (!cs_malloc(&rdr, sizeof(struct s_reader)))
-+		{
-+			return;
-+		}
-+
-+		reader_set_defaults(rdr);
-+
-+		rdr->enable = 1;
-+		rdr->typ = R_EMU;
-+		cs_strncpy(rdr->label, emuName, sizeof(emuName));
-+		cs_strncpy(rdr->device, emuName, sizeof(emuName));
-+
-+		// CAIDs
-+		ctab = strdup("0500,0604,0E00,1010,1801,2600,2602,2610");
-+		chk_caidtab(ctab, &rdr->ctab);
-+		NULLFREE(ctab);
-+
-+		// Idents
-+		ftab = strdup("0500:000000,007400,007800,021110,023800;"
-+					  "0604:000000;"
-+					  "0E00:000000;"
-+					  "1010:000000;"
-+					  "1801:000000,001101,002111,007301;"
-+					  "2600:000000;"
-+					  "2602:000000;"
-+					  "2610:000000;"
-+					 );
-+		chk_ftab(ftab, &rdr->ftab);
-+		NULLFREE(ftab);
-+
-+		// AU providers
-+		emu_auproviders = strdup("0604:010200;0E00:000000;1010:000000;2610:000000;");
-+		chk_ftab(emu_auproviders, &rdr->emu_auproviders);
-+		NULLFREE(emu_auproviders);
-+
-+		// EMM cache
-+		rdr->cachemm = 2;
-+		rdr->rewritemm = 1;
-+		rdr->logemm = 2;
-+		rdr->deviceemm = 1;
-+
-+		// User group
-+		rdr->grp = 0x1ULL;
-+
-+		// Add the "device" part to our emu reader
-+		rdr->crdr = &cardreader_emu;
-+
-+		// Disable CW checksum test for PowerVu
-+		disablecrccws_only_for = strdup("0E00:000000");
-+		chk_ftab(disablecrccws_only_for, &rdr->disablecrccws_only_for);
-+		NULLFREE(disablecrccws_only_for);
-+
-+		reader_fixups_fn(rdr);
-+		ll_append(configured_readers, rdr);
-+	}
-+
-+	// Set DVB Api delayer option
-+#ifdef HAVE_DVBAPI
-+	if (cfg.dvbapi_enabled && cfg.dvbapi_delayer < 60)
-+	{
-+		cfg.dvbapi_delayer = 60;
-+	}
-+#endif
-+
-+	cs_log("OSCam-Emu version %d", EMU_VERSION);
-+}
-+
-+#endif // WITH_EMU
-Index: oscam.c
-===================================================================
---- oscam.c	(revision 11581)
-+++ oscam.c	(working copy)
+--- oscam-svn/oscam.c	2020-09-23 22:18:25.000000000 +0200
++++ oscam-svn/oscam.c	2020-09-23 22:57:35.776549489 +0200
 @@ -41,6 +41,11 @@
  #include "reader-common.h"
  #include "module-gbox.h"
@@ -11526,7 +11465,7 @@ Index: oscam.c
  #ifdef WITH_SSL
  #include <openssl/crypto.h>
  #include <openssl/ssl.h>
-@@ -427,6 +432,8 @@
+@@ -436,6 +441,8 @@
  		case CLOCK_TYPE_MONOTONIC: write_conf(CLOCKFIX, "Clockfix with monotonic clock"); break;
  	}
  	write_conf(IPV6SUPPORT, "IPv6 support");
@@ -11535,7 +11474,7 @@ Index: oscam.c
  
  	fprintf(fp, "\n");
  	write_conf(MODULE_CAMD33, "camd 3.3x");
-@@ -1818,6 +1825,9 @@
+@@ -1833,6 +1840,9 @@
  
  	init_sidtab();
  	init_readerdb();
@@ -11545,7 +11484,7 @@ Index: oscam.c
  	cfg.account = init_userdb();
  	init_signal();
  	init_provid();
-@@ -1905,6 +1915,9 @@
+@@ -1920,6 +1930,9 @@
  if(!cfg.gsms_dis)
  	{ stop_sms_sender(); }
  #endif
@@ -11555,10 +11494,13 @@ Index: oscam.c
  	webif_close();
  	azbox_close();
  	coolapi_close_all();
-Index: webif/config/dvbapi.html
-===================================================================
---- webif/config/dvbapi.html	(revision 11581)
-+++ webif/config/dvbapi.html	(working copy)
+--- oscam-svn/.travis.yml	1970-01-01 01:00:00.000000000 +0100
++++ oscam-svn/.travis.yml	2020-09-23 22:57:35.768431210 +0200
+@@ -0,0 +1,2 @@
++language: cpp
++script: ./config.sh -E all && make
+--- oscam-svn/webif/config/dvbapi.html	2020-09-23 22:18:24.000000000 +0200
++++ oscam-svn/webif/config/dvbapi.html	2020-09-23 22:57:35.776549489 +0200
 @@ -56,7 +56,7 @@
  			</TD>
  		</TR>
@@ -11574,4 +11516,3 @@ Index: webif/config/dvbapi.html
  			</TD>
 -		</TR> -->
 +		</TR>
-\ No newline at end of file

--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -1,5 +1,5 @@
---- oscam-svn/CMakeLists.txt	2020-09-23 22:18:25.000000000 +0200
-+++ oscam-svn/CMakeLists.txt	2020-09-23 22:57:35.768431210 +0200
+--- CMakeLists.txt	2020-09-23 22:18:25.000000000 +0200
++++ CMakeLists.txt	2020-09-23 22:57:35.768431210 +0200
 @@ -101,6 +101,7 @@
  		${CMAKE_CURRENT_SOURCE_DIR}/csctapi
  		${CMAKE_CURRENT_SOURCE_DIR}/cscrypt
@@ -104,8 +104,8 @@
 +endif (WITH_EMU)
 +
  message (STATUS "")
---- oscam-svn/config.h	2020-09-23 22:18:25.000000000 +0200
-+++ oscam-svn/config.h	2020-09-23 22:57:35.768431210 +0200
+--- config.h	2020-09-23 22:18:25.000000000 +0200
++++ config.h	2020-09-23 22:57:35.768431210 +0200
 @@ -1,6 +1,8 @@
  #ifndef CONFIG_H_
  #define CONFIG_H_
@@ -115,8 +115,8 @@
  #define WEBIF 1
  #define WEBIF_LIVELOG 1
  #define WEBIF_JQUERY 1
---- oscam-svn/config.sh	2020-09-23 22:18:25.000000000 +0200
-+++ oscam-svn/config.sh	2020-09-23 23:00:02.167353804 +0200
+--- config.sh	2020-09-23 22:18:25.000000000 +0200
++++ config.sh	2020-09-23 23:00:02.167353804 +0200
 @@ -1,6 +1,6 @@
  #!/bin/sh
  
@@ -197,8 +197,8 @@
  		break
  	;;
  	'-O'|'--detect-osx-sdk-version')
---- oscam-svn/globals.h	2020-09-23 22:18:25.000000000 +0200
-+++ oscam-svn/globals.h	2020-09-23 22:57:35.772490349 +0200
+--- globals.h	2020-09-23 22:18:25.000000000 +0200
++++ globals.h	2020-09-23 22:57:35.772490349 +0200
 @@ -393,7 +393,7 @@
  #define CS_ECM_RINGBUFFER_MAX	0x10	// max size for ECM last responsetimes ringbuffer. Keep this set to power of 2 values!
  
@@ -216,8 +216,8 @@
  #endif
  	uint8_t			cnxlastecm;						// == 0 - last ecm has not been paired ecm, > 0 last ecm has been paired ecm
  	LLIST			*emmstat;						// emm stats
---- oscam-svn/Makefile	2020-09-23 22:18:26.000000000 +0200
-+++ oscam-svn/Makefile	2020-09-23 22:57:35.768431210 +0200
+--- Makefile	2020-09-23 22:18:26.000000000 +0200
++++ Makefile	2020-09-23 22:57:35.768431210 +0200
 @@ -65,6 +65,13 @@
  
  LDFLAGS = -Wl,--gc-sections
@@ -272,8 +272,8 @@
  	@-printf "\
  +-------------------------------------------------------------------------------\n\
  | OSCam ver: $(VER) rev: $(SVN_REV) target: $(TARGET)\n\
---- oscam-svn/module-dvbapi.c	2020-09-23 22:18:26.000000000 +0200
-+++ oscam-svn/module-dvbapi.c	2020-09-23 22:57:35.772490349 +0200
+--- module-dvbapi.c	2020-09-23 22:18:26.000000000 +0200
++++ module-dvbapi.c	2020-09-23 22:57:35.772490349 +0200
 @@ -2644,6 +2644,8 @@
  	er->vpid   = demux[demux_id].ECMpids[pid].VPID;
  	er->pmtpid = demux[demux_id].pmtpid;
@@ -317,8 +317,8 @@
  			cs_log("Demuxer %d trying to descramble PID %d CAID %04X PROVID %06X ECMPID %04X ANY CHID PMTPID %04X VPID %04X",
  				demux_id,
  				pid,
---- oscam-svn/module-emulator-biss.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-biss.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-biss.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-biss.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,894 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -1214,8 +1214,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-biss.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-biss.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-biss.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-biss.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,22 @@
 +#ifndef MODULE_EMULATOR_BISS_H
 +#define MODULE_EMULATOR_BISS_H
@@ -1239,8 +1239,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_BISS_H
---- oscam-svn/module-emulator.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator.c	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,904 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -2146,8 +2146,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-cryptoworks.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-cryptoworks.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-cryptoworks.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-cryptoworks.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,688 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -2837,8 +2837,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-cryptoworks.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-cryptoworks.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-cryptoworks.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-cryptoworks.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_CRYPTOWORKS_H
 +#define MODULE_EMULATOR_CRYPTOWORKS_H
@@ -2850,8 +2850,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_CRYPTOWORKS_H
---- oscam-svn/module-emulator-director.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-director.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-director.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-director.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,642 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -3495,8 +3495,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-director.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-director.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-director.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-director.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_DIRECTOR_H
 +#define MODULE_EMULATOR_DIRECTOR_H
@@ -3509,8 +3509,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_DIRECTOR_H
---- oscam-svn/module-emulator-irdeto.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-irdeto.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-irdeto.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-irdeto.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,602 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -4114,8 +4114,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-irdeto.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-irdeto.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-irdeto.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-irdeto.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,15 @@
 +#ifndef MODULE_EMULATOR_IRDETO_H
 +#define MODULE_EMULATOR_IRDETO_H
@@ -4132,8 +4132,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_IRDETO_H
---- oscam-svn/module-emulator-nagravision.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-nagravision.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-nagravision.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-nagravision.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,376 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -4511,8 +4511,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-nagravision.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-nagravision.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-nagravision.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-nagravision.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_NAGRAVISION_H
 +#define MODULE_EMULATOR_NAGRAVISION_H
@@ -4524,8 +4524,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_NAGRAVISION_H
---- oscam-svn/module-emulator-osemu.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-osemu.c	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-osemu.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-osemu.c	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,972 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -5499,8 +5499,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-osemu.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-osemu.h	2020-09-23 22:57:35.772490349 +0200
+--- module-emulator-osemu.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-osemu.h	2020-09-23 22:57:35.772490349 +0200
 @@ -0,0 +1,95 @@
 +#ifndef MODULE_EMULATOR_OSEMU_H_
 +#define MODULE_EMULATOR_OSEMU_H_
@@ -5597,8 +5597,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_H_
---- oscam-svn/module-emulator-powervu.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-powervu.c	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-powervu.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-powervu.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,2691 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -8291,8 +8291,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-powervu.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-powervu.h	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-powervu.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-powervu.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,59 @@
 +#ifndef MODULE_EMULATOR_POWERVU_H
 +#define MODULE_EMULATOR_POWERVU_H
@@ -8353,8 +8353,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_POWERVU_H
---- oscam-svn/module-emulator-streamserver.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-streamserver.c	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-streamserver.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-streamserver.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,1802 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -10158,8 +10158,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-streamserver.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-streamserver.h	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-streamserver.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-streamserver.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,90 @@
 +#ifndef MODULE_EMULATOR_STREAMSERVER_H_
 +#define MODULE_EMULATOR_STREAMSERVER_H_
@@ -10251,8 +10251,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_STREAMSERVER_H_
---- oscam-svn/module-emulator-viaccess.c	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-viaccess.c	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-viaccess.c	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-viaccess.c	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,1183 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -11437,8 +11437,8 @@
 +}
 +
 +#endif // WITH_EMU
---- oscam-svn/module-emulator-viaccess.h	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/module-emulator-viaccess.h	2020-09-23 22:57:35.776549489 +0200
+--- module-emulator-viaccess.h	1970-01-01 01:00:00.000000000 +0100
++++ module-emulator-viaccess.h	2020-09-23 22:57:35.776549489 +0200
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_VIACCESS_H
 +#define MODULE_EMULATOR_VIACCESS_H
@@ -11451,8 +11451,8 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_VIACCESS_H
---- oscam-svn/oscam.c	2020-09-23 22:18:25.000000000 +0200
-+++ oscam-svn/oscam.c	2020-09-23 22:57:35.776549489 +0200
+--- oscam.c	2020-09-23 22:18:25.000000000 +0200
++++ oscam.c	2020-09-23 22:57:35.776549489 +0200
 @@ -41,6 +41,11 @@
  #include "reader-common.h"
  #include "module-gbox.h"
@@ -11494,13 +11494,13 @@
  	webif_close();
  	azbox_close();
  	coolapi_close_all();
---- oscam-svn/.travis.yml	1970-01-01 01:00:00.000000000 +0100
-+++ oscam-svn/.travis.yml	2020-09-23 22:57:35.768431210 +0200
+--- .travis.yml	1970-01-01 01:00:00.000000000 +0100
++++ .travis.yml	2020-09-23 22:57:35.768431210 +0200
 @@ -0,0 +1,2 @@
 +language: cpp
 +script: ./config.sh -E all && make
---- oscam-svn/webif/config/dvbapi.html	2020-09-23 22:18:24.000000000 +0200
-+++ oscam-svn/webif/config/dvbapi.html	2020-09-23 22:57:35.776549489 +0200
+--- webif/config/dvbapi.html	2020-09-23 22:18:24.000000000 +0200
++++ webif/config/dvbapi.html	2020-09-23 22:57:35.776549489 +0200
 @@ -56,7 +56,7 @@
  			</TD>
  		</TR>

--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -1994,7 +1994,7 @@
 +		if (cfg.emu_stream_source_auth_user && cfg.emu_stream_source_auth_password)
 +		{
 +			snprintf(authtmp, sizeof(authtmp), "%s:%s", cfg.emu_stream_source_auth_user, cfg.emu_stream_source_auth_password);
-+			b64encode(authtmp, strlen(authtmp), &emu_stream_source_auth);
++			b64encode(authtmp, cs_strlen(authtmp), &emu_stream_source_auth);
 +		}
 +		else
 +		{
@@ -4641,7 +4641,7 @@
 +		free(emu_keyfile_path);
 +	}
 +
-+	pathLength = strlen(path);
++	pathLength = cs_strlen(path);
 +	emu_keyfile_path = (char *)malloc(pathLength + 1);
 +	if (emu_keyfile_path == NULL)
 +	{
@@ -4693,12 +4693,12 @@
 +	char line[1200], dateText[100], filename[EMU_KEY_FILENAME_MAX_LEN + 1];
 +	char *path, *filepath, *keyValue;
 +	uint32_t pathLength;
-+	uint8_t fileNameLen = strlen(EMU_KEY_FILENAME);
++	uint8_t fileNameLen = cs_strlen(EMU_KEY_FILENAME);
 +	struct dirent *pDirent;
 +	DIR *pDir;
 +	FILE *file = NULL;
 +
-+	pathLength = strlen(emu_keyfile_path);
++	pathLength = cs_strlen(emu_keyfile_path);
 +	path = (char *)malloc(pathLength + 1);
 +	if (path == NULL)
 +	{
@@ -4706,14 +4706,14 @@
 +	}
 +	cs_strncpy(path, emu_keyfile_path, pathLength + 1);
 +
-+	pathLength = strlen(path);
++	pathLength = cs_strlen(path);
 +	if (pathLength >= fileNameLen && strcasecmp(path + pathLength - fileNameLen, EMU_KEY_FILENAME) == 0)
 +	{
 +		// cut file name
 +		path[pathLength - fileNameLen] = '\0';
 +	}
 +
-+	pathLength = strlen(path);
++	pathLength = cs_strlen(path);
 +	if (path[pathLength - 1] == '/' || path[pathLength - 1] == '\\')
 +	{
 +		// cut trailing /
@@ -4743,7 +4743,7 @@
 +		cs_strncpy(filename, EMU_KEY_FILENAME, sizeof(filename));
 +	}
 +
-+	pathLength = strlen(path) + 1 + strlen(filename) + 1;
++	pathLength = cs_strlen(path) + 1 + cs_strlen(filename) + 1;
 +	filepath = (char *)malloc(pathLength);
 +	if (filepath == NULL)
 +	{
@@ -4787,7 +4787,7 @@
 +
 +	free(keyValue);
 +
-+	fwrite(line, strlen(line), 1, file);
++	fwrite(line, cs_strlen(line), 1, file);
 +	fclose(file);
 +}
 +
@@ -4818,7 +4818,7 @@
 +		}
 +
 +		// All keyNames should have a length of 8 after converting
-+		if (strlen(keyName) != 8)
++		if (cs_strlen(keyName) != 8)
 +		{
 +			cs_log("WARNING: Wrong key format in %s: F %08X %s", EMU_KEY_FILENAME, provider, keyName);
 +			return 0;
@@ -4916,7 +4916,7 @@
 +			newKeyData->identifier = identifier;
 +			newKeyData->provider = provider;
 +
-+			if (strlen(keyName) < EMU_MAX_CHAR_KEYNAME)
++			if (cs_strlen(keyName) < EMU_MAX_CHAR_KEYNAME)
 +			{
 +				cs_strncpy(newKeyData->keyName, keyName, EMU_MAX_CHAR_KEYNAME);
 +			}
@@ -5003,7 +5003,7 @@
 +	KeyDB->EmuKeys[KeyDB->keyCount].identifier = identifier;
 +	KeyDB->EmuKeys[KeyDB->keyCount].provider = provider;
 +
-+	if (strlen(keyName) < EMU_MAX_CHAR_KEYNAME)
++	if (cs_strlen(keyName) < EMU_MAX_CHAR_KEYNAME)
 +	{
 +		cs_strncpy(KeyDB->EmuKeys[KeyDB->keyCount].keyName, keyName, EMU_MAX_CHAR_KEYNAME);
 +	}
@@ -5221,13 +5221,13 @@
 +	char line[1200], keyName[EMU_MAX_CHAR_KEYNAME], keyString[1026], identifier;
 +	char *path, *filepath, filename[EMU_KEY_FILENAME_MAX_LEN + 1];
 +	uint32_t pathLength, provider, keyLength;
-+	uint8_t fileNameLen = strlen(EMU_KEY_FILENAME);
++	uint8_t fileNameLen = cs_strlen(EMU_KEY_FILENAME);
 +	uint8_t *key;
 +	struct dirent *pDirent;
 +	DIR *pDir;
 +	FILE *file = NULL;
 +
-+	pathLength = strlen(opath);
++	pathLength = cs_strlen(opath);
 +	path = (char *)malloc(pathLength + 1);
 +	if (path == NULL)
 +	{
@@ -5235,14 +5235,14 @@
 +	}
 +	cs_strncpy(path, opath, pathLength + 1);
 +
-+	pathLength = strlen(path);
++	pathLength = cs_strlen(path);
 +	if (pathLength >= fileNameLen && strcasecmp(path + pathLength - fileNameLen, EMU_KEY_FILENAME) == 0)
 +	{
 +		// cut file name
 +		path[pathLength - fileNameLen] = '\0';
 +	}
 +
-+	pathLength = strlen(path);
++	pathLength = cs_strlen(path);
 +	if (path[pathLength - 1] == '/' || path[pathLength - 1] == '\\')
 +	{
 +		// cut trailing /
@@ -5274,7 +5274,7 @@
 +		return 0;
 +	}
 +
-+	pathLength = strlen(path) + 1 + strlen(filename) + 1;
++	pathLength = cs_strlen(path) + 1 + cs_strlen(filename) + 1;
 +	filepath = (char *)malloc(pathLength);
 +	if (filepath == NULL)
 +	{
@@ -5302,7 +5302,7 @@
 +			continue;
 +		}
 +
-+		keyLength = strlen(keyString) / 2;
++		keyLength = cs_strlen(keyString) / 2;
 +		key = (uint8_t *)malloc(keyLength);
 +		if (key == NULL)
 +		{
@@ -5310,7 +5310,7 @@
 +			return 0;
 +		}
 +
-+		if (char_to_bin(key, keyString, strlen(keyString))) // Conversion OK
++		if (char_to_bin(key, keyString, cs_strlen(keyString))) // Conversion OK
 +		{
 +			emu_set_key(identifier, provider, keyName, key, keyLength, 0, NULL, rdr);
 +		}
@@ -5360,7 +5360,7 @@
 +			continue;
 +		}
 +
-+		keyLength = strlen(keyString) / 2;
++		keyLength = cs_strlen(keyString) / 2;
 +
 +		key = (uint8_t *)malloc(keyLength);
 +		if (key == NULL)
@@ -5369,7 +5369,7 @@
 +			return;
 +		}
 +
-+		if (char_to_bin(key, keyString, strlen(keyString))) // Conversion OK
++		if (char_to_bin(key, keyString, cs_strlen(keyString))) // Conversion OK
 +		{
 +			emu_set_key(identifier, provider, keyName, key, keyLength, 0, NULL, rdr);
 +		}
@@ -8190,7 +8190,7 @@
 +				continue;
 +			}
 +
-+			length = strlen(KeyDB->EmuKeys[j].keyName);
++			length = cs_strlen(KeyDB->EmuKeys[j].keyName);
 +
 +			if (length < 3)
 +			{
@@ -8256,7 +8256,7 @@
 +			continue;
 +		}
 +
-+		length = strlen(KeyDB->EmuKeys[i].keyName);
++		length = cs_strlen(KeyDB->EmuKeys[i].keyName);
 +
 +		if (length < 3)
 +		{
@@ -9627,7 +9627,7 @@
 +				"Connection: keep-alive\n\n", stream_path, emu_stream_source_host, emu_stream_source_port);
 +	}
 +
-+	if (send(streamfd, http_buf, strlen(http_buf), 0) == -1)
++	if (send(streamfd, http_buf, cs_strlen(http_buf), 0) == -1)
 +	{
 +		return -1;
 +	}
@@ -9768,7 +9768,7 @@
 +				conndata->connid, data->srvid, data->tsid, data->onid, data->ens);
 +
 +	snprintf(http_buf, 1024, "HTTP/1.0 200 OK\nConnection: Close\nContent-Type: video/mpeg\nServer: stream_enigma2\n\n");
-+	clientStatus = send(conndata->connfd, http_buf, strlen(http_buf), 0);
++	clientStatus = send(conndata->connfd, http_buf, cs_strlen(http_buf), 0);
 +
 +	data->connid = conndata->connid;
 +	data->caid = NO_CAID_VALUE;

--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -7077,7 +7077,7 @@ Index: module-emulator-powervu.c
 +static void unmask_emm(uint8_t *emm)
 +{
 +	uint32_t crc, i, l;
-+	uint8_t hashModeEmm, modeUnmask, data[30], mask[16];
++	uint8_t hashModeEmm, modeUnmask, data[41], mask[16];
 +
 +	uint8_t sourcePos[] =
 +	{

--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -7,7 +7,7 @@ Index: .travis.yml
 +script: ./config.sh -E all && make
 Index: CMakeLists.txt
 ===================================================================
---- CMakeLists.txt	(revision 11657)
+--- CMakeLists.txt	(revision 11666)
 +++ CMakeLists.txt	(working copy)
 @@ -101,6 +101,7 @@
  		${CMAKE_CURRENT_SOURCE_DIR}/csctapi
@@ -115,7 +115,7 @@ Index: CMakeLists.txt
  message (STATUS "")
 Index: Makefile
 ===================================================================
---- Makefile	(revision 11657)
+--- Makefile	(revision 11666)
 +++ Makefile	(working copy)
 @@ -65,6 +65,13 @@
  
@@ -173,7 +173,7 @@ Index: Makefile
  | OSCam ver: $(VER) rev: $(SVN_REV) target: $(TARGET)\n\
 Index: config.h
 ===================================================================
---- config.h	(revision 11657)
+--- config.h	(revision 11666)
 +++ config.h	(working copy)
 @@ -1,6 +1,8 @@
  #ifndef CONFIG_H_
@@ -186,7 +186,7 @@ Index: config.h
  #define WEBIF_JQUERY 1
 Index: config.sh
 ===================================================================
---- config.sh	(revision 11657)
+--- config.sh	(revision 11666)
 +++ config.sh	(working copy)
 @@ -1,6 +1,6 @@
  #!/bin/sh
@@ -273,7 +273,7 @@ old mode 100644
 new mode 100755
 Index: globals.h
 ===================================================================
---- globals.h	(revision 11657)
+--- globals.h	(revision 11666)
 +++ globals.h	(working copy)
 @@ -393,7 +393,7 @@
  #define CS_ECM_RINGBUFFER_MAX	0x10	// max size for ECM last responsetimes ringbuffer. Keep this set to power of 2 values!
@@ -294,7 +294,7 @@ Index: globals.h
  	LLIST			*emmstat;						// emm stats
 Index: module-dvbapi.c
 ===================================================================
---- module-dvbapi.c	(revision 11657)
+--- module-dvbapi.c	(revision 11666)
 +++ module-dvbapi.c	(working copy)
 @@ -2644,6 +2644,8 @@
  	er->vpid   = demux[demux_id].ECMpids[pid].VPID;
@@ -11513,7 +11513,7 @@ Index: module-emulator.c
 +#endif // WITH_EMU
 Index: oscam.c
 ===================================================================
---- oscam.c	(revision 11657)
+--- oscam.c	(revision 11666)
 +++ oscam.c	(working copy)
 @@ -41,6 +41,11 @@
  #include "reader-common.h"
@@ -11558,7 +11558,7 @@ Index: oscam.c
  	coolapi_close_all();
 Index: webif/config/dvbapi.html
 ===================================================================
---- webif/config/dvbapi.html	(revision 11657)
+--- webif/config/dvbapi.html	(revision 11666)
 +++ webif/config/dvbapi.html	(working copy)
 @@ -56,7 +56,7 @@
  			</TD>

--- a/oscam-emu.patch
+++ b/oscam-emu.patch
@@ -1,5 +1,14 @@
---- CMakeLists.txt	2020-09-23 22:18:25.000000000 +0200
-+++ CMakeLists.txt	2020-09-23 22:57:35.768431210 +0200
+Index: .travis.yml
+===================================================================
+--- .travis.yml	(nonexistent)
++++ .travis.yml	(working copy)
+@@ -0,0 +1,2 @@
++language: cpp
++script: ./config.sh -E all && make
+Index: CMakeLists.txt
+===================================================================
+--- CMakeLists.txt	(revision 11657)
++++ CMakeLists.txt	(working copy)
 @@ -101,6 +101,7 @@
  		${CMAKE_CURRENT_SOURCE_DIR}/csctapi
  		${CMAKE_CURRENT_SOURCE_DIR}/cscrypt
@@ -104,8 +113,68 @@
 +endif (WITH_EMU)
 +
  message (STATUS "")
---- config.h	2020-09-23 22:18:25.000000000 +0200
-+++ config.h	2020-09-23 22:57:35.768431210 +0200
+Index: Makefile
+===================================================================
+--- Makefile	(revision 11657)
++++ Makefile	(working copy)
+@@ -65,6 +65,13 @@
+ 
+ LDFLAGS = -Wl,--gc-sections
+ 
++TARGETHELP := $(shell $(CC) --target-help 2>&1)
++ifneq (,$(findstring sse2,$(TARGETHELP)))
++override CFLAGS += -fexpensive-optimizations -mmmx -msse -msse2 -msse3
++else
++override CFLAGS += -fexpensive-optimizations
++endif
++
+ # The linker for powerpc have bug that prevents --gc-sections from working
+ # Check for the linker version and if it matches disable --gc-sections
+ # For more information about the bug see:
+@@ -271,6 +278,30 @@
+ SRC-$(CONFIG_MODULE_CCCAM) += module-cccam.c
+ SRC-$(CONFIG_MODULE_CCCSHARE) += module-cccshare.c
+ SRC-$(CONFIG_MODULE_CONSTCW) += module-constcw.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-osemu.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-streamserver.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-biss.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-cryptoworks.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-director.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-irdeto.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-nagravision.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-powervu.c
++SRC-$(CONFIG_WITH_EMU) += module-emulator-viaccess.c
++SRC-$(CONFIG_WITH_EMU) += ffdecsa/ffdecsa.c
++ifeq "$(CONFIG_WITH_EMU)" "y"
++ifeq "$(CONFIG_WITH_SOFTCAM)" "y"
++UNAME := $(shell uname -s)
++ifneq ($(UNAME),Darwin)
++ifndef ANDROID_NDK
++ifndef ANDROID_STANDALONE_TOOLCHAIN
++TOUCH_SK := $(shell touch SoftCam.Key)
++override LDFLAGS += -Wl,--format=binary -Wl,SoftCam.Key -Wl,--format=default
++endif
++endif
++endif
++endif
++endif
+ SRC-$(CONFIG_CS_CACHEEX) += module-csp.c
+ SRC-$(CONFIG_CW_CYCLE_CHECK) += module-cw-cycle-check.c
+ SRC-$(CONFIG_WITH_AZBOX) += module-dvbapi-azbox.c
+@@ -371,7 +402,7 @@
+ # starts the compilation.
+ all:
+ 	@./config.sh --use-flags "$(USE_FLAGS)" --objdir "$(OBJDIR)" --make-config.mak
+-	@-mkdir -p $(OBJDIR)/cscrypt $(OBJDIR)/csctapi $(OBJDIR)/minilzo $(OBJDIR)/webif
++	@-mkdir -p $(OBJDIR)/cscrypt $(OBJDIR)/csctapi $(OBJDIR)/minilzo $(OBJDIR)/ffdecsa $(OBJDIR)/webif
+ 	@-printf "\
+ +-------------------------------------------------------------------------------\n\
+ | OSCam ver: $(VER) rev: $(SVN_REV) target: $(TARGET)\n\
+Index: config.h
+===================================================================
+--- config.h	(revision 11657)
++++ config.h	(working copy)
 @@ -1,6 +1,8 @@
  #ifndef CONFIG_H_
  #define CONFIG_H_
@@ -115,8 +184,10 @@
  #define WEBIF 1
  #define WEBIF_LIVELOG 1
  #define WEBIF_JQUERY 1
---- config.sh	2020-09-23 22:18:25.000000000 +0200
-+++ config.sh	2020-09-23 23:00:02.167353804 +0200
+Index: config.sh
+===================================================================
+--- config.sh	(revision 11657)
++++ config.sh	(working copy)
 @@ -1,6 +1,6 @@
  #!/bin/sh
  
@@ -197,8 +268,13 @@
  		break
  	;;
  	'-O'|'--detect-osx-sdk-version')
---- globals.h	2020-09-23 22:18:25.000000000 +0200
-+++ globals.h	2020-09-23 22:57:35.772490349 +0200
+Index: git-svn-diff.sh
+old mode 100644
+new mode 100755
+Index: globals.h
+===================================================================
+--- globals.h	(revision 11657)
++++ globals.h	(working copy)
 @@ -393,7 +393,7 @@
  #define CS_ECM_RINGBUFFER_MAX	0x10	// max size for ECM last responsetimes ringbuffer. Keep this set to power of 2 values!
  
@@ -216,64 +292,10 @@
  #endif
  	uint8_t			cnxlastecm;						// == 0 - last ecm has not been paired ecm, > 0 last ecm has been paired ecm
  	LLIST			*emmstat;						// emm stats
---- Makefile	2020-09-23 22:18:26.000000000 +0200
-+++ Makefile	2020-09-23 22:57:35.768431210 +0200
-@@ -65,6 +65,13 @@
- 
- LDFLAGS = -Wl,--gc-sections
- 
-+TARGETHELP := $(shell $(CC) --target-help 2>&1)
-+ifneq (,$(findstring sse2,$(TARGETHELP)))
-+override CFLAGS += -fexpensive-optimizations -mmmx -msse -msse2 -msse3
-+else
-+override CFLAGS += -fexpensive-optimizations
-+endif
-+
- # The linker for powerpc have bug that prevents --gc-sections from working
- # Check for the linker version and if it matches disable --gc-sections
- # For more information about the bug see:
-@@ -271,6 +278,30 @@
- SRC-$(CONFIG_MODULE_CCCAM) += module-cccam.c
- SRC-$(CONFIG_MODULE_CCCSHARE) += module-cccshare.c
- SRC-$(CONFIG_MODULE_CONSTCW) += module-constcw.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-osemu.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-streamserver.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-biss.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-cryptoworks.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-director.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-irdeto.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-nagravision.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-powervu.c
-+SRC-$(CONFIG_WITH_EMU) += module-emulator-viaccess.c
-+SRC-$(CONFIG_WITH_EMU) += ffdecsa/ffdecsa.c
-+ifeq "$(CONFIG_WITH_EMU)" "y"
-+ifeq "$(CONFIG_WITH_SOFTCAM)" "y"
-+UNAME := $(shell uname -s)
-+ifneq ($(UNAME),Darwin)
-+ifndef ANDROID_NDK
-+ifndef ANDROID_STANDALONE_TOOLCHAIN
-+TOUCH_SK := $(shell touch SoftCam.Key)
-+override LDFLAGS += -Wl,--format=binary -Wl,SoftCam.Key -Wl,--format=default
-+endif
-+endif
-+endif
-+endif
-+endif
- SRC-$(CONFIG_CS_CACHEEX) += module-csp.c
- SRC-$(CONFIG_CW_CYCLE_CHECK) += module-cw-cycle-check.c
- SRC-$(CONFIG_WITH_AZBOX) += module-dvbapi-azbox.c
-@@ -371,7 +402,7 @@
- # starts the compilation.
- all:
- 	@./config.sh --use-flags "$(USE_FLAGS)" --objdir "$(OBJDIR)" --make-config.mak
--	@-mkdir -p $(OBJDIR)/cscrypt $(OBJDIR)/csctapi $(OBJDIR)/minilzo $(OBJDIR)/webif
-+	@-mkdir -p $(OBJDIR)/cscrypt $(OBJDIR)/csctapi $(OBJDIR)/minilzo $(OBJDIR)/ffdecsa $(OBJDIR)/webif
- 	@-printf "\
- +-------------------------------------------------------------------------------\n\
- | OSCam ver: $(VER) rev: $(SVN_REV) target: $(TARGET)\n\
---- module-dvbapi.c	2020-09-23 22:18:26.000000000 +0200
-+++ module-dvbapi.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-dvbapi.c
+===================================================================
+--- module-dvbapi.c	(revision 11657)
++++ module-dvbapi.c	(working copy)
 @@ -2644,6 +2644,8 @@
  	er->vpid   = demux[demux_id].ECMpids[pid].VPID;
  	er->pmtpid = demux[demux_id].pmtpid;
@@ -317,8 +339,10 @@
  			cs_log("Demuxer %d trying to descramble PID %d CAID %04X PROVID %06X ECMPID %04X ANY CHID PMTPID %04X VPID %04X",
  				demux_id,
  				pid,
---- module-emulator-biss.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-biss.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-biss.c
+===================================================================
+--- module-emulator-biss.c	(nonexistent)
++++ module-emulator-biss.c	(working copy)
 @@ -0,0 +1,894 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -1214,8 +1238,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-biss.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-biss.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-biss.h
+===================================================================
+--- module-emulator-biss.h	(nonexistent)
++++ module-emulator-biss.h	(working copy)
 @@ -0,0 +1,22 @@
 +#ifndef MODULE_EMULATOR_BISS_H
 +#define MODULE_EMULATOR_BISS_H
@@ -1239,915 +1265,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_BISS_H
---- module-emulator.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator.c	2020-09-23 22:57:35.776549489 +0200
-@@ -0,0 +1,904 @@
-+#define MODULE_LOG_PREFIX "emu"
-+
-+#include "globals.h"
-+
-+#ifdef WITH_EMU
-+
-+#include "module-emulator-osemu.h"
-+#include "module-emulator-streamserver.h"
-+#include "module-emulator-biss.h"
-+#include "module-emulator-irdeto.h"
-+#include "module-emulator-powervu.h"
-+#include "oscam-conf-chk.h"
-+#include "oscam-config.h"
-+#include "oscam-reader.h"
-+#include "oscam-string.h"
-+
-+/*
-+ * Readers in OSCam consist of 2 basic parts.
-+ * The hardware or the device part. This is where physical smart cards are inserted
-+ * and made available to OSCam.
-+ * The software or the emulation part. This is where the actual card reading is done,
-+ * including ecm and emm processing (i.e emulation of the various cryptosystems).
-+ * In the Emu reader, the device part has no meaning, but we have to create it in
-+ * order to be compatible with OSCam's reader structure.
-+*/
-+
-+/*
-+ * Create the Emu "emulation" part. This is of type s_cardsystem.
-+ * Similar structures are found in the main sources folder (files reader-xxxxxx.c)
-+ * for every cryptosystem supported by OSCam.
-+ * Here we read keys from our virtual card (aka the SoftCam.Key file) and we inform
-+ * OSCam about them. This is done with the emu_card_info() function. Keep in mind
-+ * that Emu holds all its keys to separate structures for faster access.
-+ * In addition, ECM and EMM requests are processed here, with the emu_do_ecm() and
-+ * emu_do_emm() functions.
-+*/
-+
-+#define CS_OK    1
-+#define CS_ERROR 0
-+
-+extern char cs_confdir[128];
-+static int8_t emu_key_data_mutex_init = 0;
-+pthread_mutex_t emu_key_data_mutex;
-+
-+static void set_hexserial_to_version(struct s_reader *rdr)
-+{
-+	char cVersion[32];
-+	uint32_t version = EMU_VERSION;
-+	uint8_t hversion[2];
-+	memset(hversion, 0, 2);
-+	snprintf(cVersion, sizeof(cVersion), "%04d", version);
-+	char_to_bin(hversion, cVersion, 4);
-+	rdr->hexserial[3] = hversion[0];
-+	rdr->hexserial[4] = hversion[1];
-+}
-+
-+static void set_prids(struct s_reader *rdr)
-+{
-+	int32_t i, j;
-+
-+	rdr->nprov = 0;
-+
-+	for (i = 0; (i < rdr->emu_auproviders.nfilts) && (rdr->nprov < CS_MAXPROV); i++)
-+	{
-+		for (j = 0; (j < rdr->emu_auproviders.filts[i].nprids) && (rdr->nprov < CS_MAXPROV); j++)
-+		{
-+			i2b_buf(4, rdr->emu_auproviders.filts[i].prids[j], rdr->prid[i]);
-+			rdr->nprov++;
-+		}
-+	}
-+}
-+
-+static void emu_add_entitlement(struct s_reader *rdr, uint16_t caid, uint32_t provid, uint8_t *key, char *keyName, uint32_t keyLength, uint8_t isData)
-+{
-+	if (!rdr->ll_entitlements)
-+	{
-+		rdr->ll_entitlements = ll_create("ll_entitlements");
-+	}
-+
-+	S_ENTITLEMENT *item;
-+	if (cs_malloc(&item, sizeof(S_ENTITLEMENT)))
-+	{
-+		// fill item
-+		item->caid = caid;
-+		item->provid = provid;
-+		item->id = 0;
-+		item->class = 0;
-+		item->start = 0;
-+		item->end = 2147472000;
-+		item->type = 0;
-+		item->isKey = 1;
-+		memcpy(item->name, keyName, 8);
-+		item->key = key;
-+		item->keyLength = keyLength;
-+		item->isData = isData;
-+
-+		// add item
-+		ll_append(rdr->ll_entitlements, item);
-+	}
-+}
-+
-+static void refresh_entitlements(struct s_reader *rdr)
-+{
-+	uint32_t i;
-+	uint16_t caid;
-+	KeyData *tmpKeyData;
-+	LL_ITER itr;
-+	biss2_rsa_key_t *item;
-+
-+	cs_clear_entitlement(rdr);
-+
-+	for (i = 0; i < StreamKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, b2i(2, StreamKeys.EmuKeys[i].key), StreamKeys.EmuKeys[i].provider, StreamKeys.EmuKeys[i].key,
-+							StreamKeys.EmuKeys[i].keyName, StreamKeys.EmuKeys[i].keyLength, 1);
-+	}
-+
-+	for (i = 0; i < ViKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x0500, ViKeys.EmuKeys[i].provider, ViKeys.EmuKeys[i].key,
-+							ViKeys.EmuKeys[i].keyName, ViKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < IrdetoKeys.keyCount; i++)
-+	{
-+		tmpKeyData = &IrdetoKeys.EmuKeys[i];
-+		do
-+		{
-+			emu_add_entitlement(rdr, tmpKeyData->provider >> 8, tmpKeyData->provider & 0xFF,
-+								tmpKeyData->key, tmpKeyData->keyName, tmpKeyData->keyLength, 0);
-+
-+			tmpKeyData = tmpKeyData->nextKey;
-+		}
-+		while (tmpKeyData != NULL);
-+	}
-+
-+	for (i = 0; i < CwKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, CwKeys.EmuKeys[i].provider >> 8, CwKeys.EmuKeys[i].provider & 0xFF,
-+							CwKeys.EmuKeys[i].key, CwKeys.EmuKeys[i].keyName, CwKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < PowervuKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x0E00, PowervuKeys.EmuKeys[i].provider, PowervuKeys.EmuKeys[i].key,
-+							PowervuKeys.EmuKeys[i].keyName, PowervuKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < TandbergKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x1010, TandbergKeys.EmuKeys[i].provider, TandbergKeys.EmuKeys[i].key,
-+							TandbergKeys.EmuKeys[i].keyName, TandbergKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	for (i = 0; i < NagraKeys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x1801, NagraKeys.EmuKeys[i].provider, NagraKeys.EmuKeys[i].key,
-+							NagraKeys.EmuKeys[i].keyName, NagraKeys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// Session words for BISS1 mode 1/E (caid 2600) and BISS2 mode 1/E (caid 2602)
-+	for (i = 0; i < BissSWs.keyCount; i++)
-+	{
-+		caid = (BissSWs.EmuKeys[i].keyLength == 8) ? 0x2600 : 0x2602;
-+		emu_add_entitlement(rdr, caid, BissSWs.EmuKeys[i].provider, BissSWs.EmuKeys[i].key,
-+							BissSWs.EmuKeys[i].keyName, BissSWs.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// Session keys (ECM keys) for BISS2 mode CA
-+	for (i = 0; i < Biss2Keys.keyCount; i++)
-+	{
-+		emu_add_entitlement(rdr, 0x2610, Biss2Keys.EmuKeys[i].provider, Biss2Keys.EmuKeys[i].key,
-+							Biss2Keys.EmuKeys[i].keyName, Biss2Keys.EmuKeys[i].keyLength, 0);
-+	}
-+
-+	// RSA keys (EMM keys) for BISS2 mode CA
-+	itr = ll_iter_create(rdr->ll_biss2_rsa_keys);
-+	while ((item = ll_iter_next(&itr)))
-+	{
-+		emu_add_entitlement(rdr, 0x2610, 0, item->ekid, "RSAPRI", 8, 0);
-+	}
-+}
-+
-+static int32_t emu_do_ecm(struct s_reader *rdr, const ECM_REQUEST *er, struct s_ecm_answer *ea)
-+{
-+	if (!emu_process_ecm(rdr, er, ea->cw, &ea->cw_ex))
-+	{
-+		return CS_OK;
-+	}
-+
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_do_emm(struct s_reader *rdr, EMM_PACKET *emm)
-+{
-+	uint32_t keysAdded = 0;
-+
-+	if (emm->emmlen < 3)
-+	{
-+		return CS_ERROR;
-+	}
-+
-+	if (SCT_LEN(emm->emm) > emm->emmlen)
-+	{
-+		return CS_ERROR;
-+	}
-+
-+	if (!emu_process_emm(rdr, b2i(2, emm->caid), emm->emm, &keysAdded))
-+	{
-+		if (keysAdded > 0)
-+		{
-+			refresh_entitlements(rdr);
-+		}
-+
-+		return CS_OK;
-+	}
-+
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_card_info(struct s_reader *rdr)
-+{
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+
-+	// Delete keys from Emu's memory
-+	emu_clear_keydata();
-+
-+	// Delete BISS2 mode CA RSA keys
-+	ll_destroy_data(&rdr->ll_biss2_rsa_keys);
-+
-+	// Read keys built in the OSCam-Emu binary
-+	emu_read_keymemory(rdr);
-+
-+	// Read keys from SoftCam.Key file
-+	emu_set_keyfile_path(cs_confdir);
-+
-+	if (!emu_read_keyfile(rdr, cs_confdir))
-+	{
-+		if (emu_read_keyfile(rdr, "/var/keys/"))
-+		{
-+			emu_set_keyfile_path("/var/keys/");
-+		}
-+	}
-+
-+	// Read BISS2 mode CA RSA keys from PEM files
-+	biss_read_pem(rdr, BISS2_MAX_RSA_KEYS);
-+
-+	cs_log("Total keys in memory: W:%d V:%d N:%d I:%d F:%d G:%d P:%d T:%d A:%d",
-+			CwKeys.keyCount, ViKeys.keyCount, NagraKeys.keyCount, IrdetoKeys.keyCount,
-+			BissSWs.keyCount, Biss2Keys.keyCount, PowervuKeys.keyCount, TandbergKeys.keyCount,
-+			StreamKeys.keyCount);
-+
-+	// Inform OSCam about all available keys.
-+	// This is used for listing the "entitlements" in the webif's reader page.
-+	refresh_entitlements(rdr);
-+
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	set_prids(rdr);
-+
-+	set_hexserial_to_version(rdr);
-+
-+	return CS_OK;
-+}
-+
-+/*
-+static int32_t emu_card_init(struct s_reader *UNUSED(rdr), struct s_ATR *UNUSED(atr))
-+{
-+	return CS_ERROR;
-+}
-+*/
-+
-+int32_t emu_get_via3_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	uint32_t provid = 0;
-+
-+	if(ep->emm[3] == 0x90 && ep->emm[4] == 0x03)
-+	{
-+		provid = b2i(3, ep->emm + 5);
-+		provid &= 0xFFFFF0;
-+		i2b_buf(4, provid, ep->provid);
-+	}
-+
-+	switch (ep->emm[0])
-+	{
-+		case 0x88:
-+			ep->type = UNIQUE;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, 4);
-+			rdr_log_dbg(rdr, D_EMM, "UNIQUE");
-+			return 1;
-+
-+		case 0x8A:
-+		case 0x8B:
-+			ep->type = GLOBAL;
-+			rdr_log_dbg(rdr, D_EMM, "GLOBAL");
-+			return 1;
-+
-+		case 0x8C:
-+		case 0x8D:
-+			ep->type = SHARED;
-+			rdr_log_dbg(rdr, D_EMM, "SHARED (part)");
-+			// We need those packets to pass otherwise we would never
-+			// be able to complete EMM reassembly
-+			return 1;
-+
-+		case 0x8E:
-+			ep->type = SHARED;
-+			rdr_log_dbg(rdr, D_EMM, "SHARED");
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 3, 3);
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+int32_t emu_get_ird2_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	int32_t l = (ep->emm[3] & 0x07);
-+	int32_t base = (ep->emm[3] >> 3);
-+	char dumprdrserial[l * 3], dumpemmserial[l * 3];
-+
-+	switch (l)
-+	{
-+		case 0:
-+			// global emm, 0 bytes addressed
-+			ep->type = GLOBAL;
-+			rdr_log_dbg(rdr, D_EMM, "GLOBAL base = %02x", base);
-+			return 1;
-+
-+		case 2:
-+			// shared emm, 2 bytes addressed
-+			ep->type = SHARED;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, l);
-+			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
-+			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
-+			rdr_log_dbg_sensitive(rdr, D_EMM, "SHARED l = %d ep = {%s} rdr = {%s} base = %02x",
-+									l, dumpemmserial, dumprdrserial, base);
-+			return 1;
-+
-+		case 3:
-+			// unique emm, 3 bytes addressed
-+			ep->type = UNIQUE;
-+			memset(ep->hexserial, 0, 8);
-+			memcpy(ep->hexserial, ep->emm + 4, l);
-+			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
-+			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
-+			rdr_log_dbg_sensitive(rdr, D_EMM, "UNIQUE l = %d ep = {%s} rdr = {%s} base = %02x",
-+									l, dumpemmserial, dumprdrserial, base);
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+int32_t emu_get_pvu_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	if (ep->emm[0] == 0x82)
-+	{
-+		ep->type = UNIQUE;
-+		memset(ep->hexserial, 0, 8);
-+		memcpy(ep->hexserial, ep->emm + 12, 4);
-+	}
-+	else
-+	{
-+		ep->type = UNKNOWN;
-+		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+	}
-+	return 1;
-+}
-+
-+int32_t emu_get_tan_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	if (ep->emm[0] == 0x82 || ep->emm[0] == 0x83)
-+	{
-+		ep->type = GLOBAL;
-+	}
-+	else
-+	{
-+		ep->type = UNKNOWN;
-+		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+	}
-+	return 1;
-+}
-+
-+int32_t emu_get_biss_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
-+{
-+	switch (ep->emm[0])
-+	{
-+		case 0x81: // Spec say this is for EMM, but oscam (and all other crypto systems) use it for ECM
-+		case 0x82:
-+		case 0x83:
-+		case 0x84:
-+		case 0x85:
-+		case 0x86:
-+		case 0x87:
-+		case 0x88:
-+		case 0x89:
-+		case 0x8A:
-+		case 0x8B:
-+		case 0x8C:
-+		case 0x8D:
-+		case 0x8E:
-+		case 0x8F:
-+			ep->type = GLOBAL;
-+			return 1;
-+
-+		default:
-+			ep->type = UNKNOWN;
-+			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
-+			return 1;
-+	}
-+}
-+
-+static int32_t emu_get_emm_type(struct emm_packet_t *ep, struct s_reader *rdr)
-+{
-+	uint16_t caid = b2i(2, ep->caid);
-+
-+	if (caid_is_viaccess(caid))     return emu_get_via3_emm_type(ep, rdr);
-+	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_type(ep, rdr);
-+	if (caid_is_powervu(caid))      return emu_get_pvu_emm_type(ep, rdr);
-+	if (caid_is_director(caid))     return emu_get_tan_emm_type(ep, rdr);
-+	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_type(ep, rdr);
-+
-+	return CS_ERROR;
-+}
-+
-+FILTER *get_emu_prids_for_caid(struct s_reader *rdr, uint16_t caid)
-+{
-+	int32_t i;
-+
-+	for (i = 0; i < rdr->emu_auproviders.nfilts; i++)
-+	{
-+		if (caid == rdr->emu_auproviders.filts[i].caid)
-+		{
-+			return &rdr->emu_auproviders.filts[i];
-+		}
-+	}
-+
-+	return NULL;
-+}
-+
-+static int32_t emu_get_via3_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 1;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x8A;
-+		filters[idx].mask[0]   = 0xFE;
-+		filters[idx].filter[3] = 0x80;
-+		filters[idx].mask[3]   = 0x80;
-+		idx++;
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_ird2_emm_filter(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t caid, uint32_t UNUSED(provid))
-+{
-+	uint8_t hexserial[3], prid[4];
-+	FILTER *emu_provids;
-+	int8_t have_provid = 0, have_serial = 0;
-+	int32_t i;
-+
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	if(irdeto2_get_hexserial(caid, hexserial))
-+	{
-+		have_serial = 1;
-+	}
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	emu_provids = get_emu_prids_for_caid(rdr, caid);
-+	if (emu_provids != NULL && emu_provids->nprids > 0)
-+	{
-+		have_provid = 1;
-+	}
-+
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = have_serial + (2 * (have_provid ? emu_provids->nprids : 0));
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		unsigned int idx = 0;
-+
-+		if (have_serial)
-+		{
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFB;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], hexserial, 3);
-+			memset(&filters[idx].mask[2], 0xFF, 3);
-+			idx++;
-+		}
-+
-+		for (i = 0; have_provid && i < emu_provids->nprids; i++)
-+		{
-+			i2b_buf(4, emu_provids->prids[i], prid);
-+
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFB;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], &prid[1], 3);
-+			memset(&filters[idx].mask[2], 0xFF, 3);
-+			idx++;
-+
-+			filters[idx].type = EMM_SHARED;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x82;
-+			filters[idx].mask[0]   = 0xFF;
-+			filters[idx].filter[1] = 0xFA;
-+			filters[idx].mask[1]   = 0x07;
-+			memcpy(&filters[idx].filter[2], &prid[1], 2);
-+			memset(&filters[idx].mask[2], 0xFF, 2);
-+			idx++;
-+		}
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_pvu_emm_filter(struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
-+										uint16_t caid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
-+{
-+	uint8_t hexserials[32][4];
-+	uint32_t i, count = 0;
-+
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	count = powervu_get_hexserials_new(hexserials, 32, caid, tsid, onid, ens);
-+	if (count == 0)
-+	{
-+		count = powervu_get_hexserials(hexserials, 32, srvid);
-+		if (count == 0)
-+		{
-+			SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+			return CS_ERROR;
-+		}
-+	}
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = count;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		for (i = 0; i < count; i++)
-+		{
-+			filters[idx].type = EMM_UNIQUE;
-+			filters[idx].enabled    = 1;
-+			filters[idx].filter[0]  = 0x82;
-+			filters[idx].filter[10] = hexserials[i][0];
-+			filters[idx].filter[11] = hexserials[i][1];
-+			filters[idx].filter[12] = hexserials[i][2];
-+			filters[idx].filter[13] = hexserials[i][3];
-+			filters[idx].mask[0]    = 0xFF;
-+			filters[idx].mask[10]   = 0xFF;
-+			filters[idx].mask[11]   = 0xFF;
-+			filters[idx].mask[12]   = 0xFF;
-+			filters[idx].mask[13]   = 0xFF;
-+			idx++;
-+		}
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_tan_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 2;
-+		uint8_t buf[8];
-+
-+		if (!emu_find_key('T', 0x40, 0, "MK", buf, 8, 0, 0, 0, NULL) &&
-+			!emu_find_key('T', 0x40, 0, "MK01", buf, 8, 0, 0, 0, NULL))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x82;
-+		filters[idx].mask[0]   = 0xFF;
-+		idx++;
-+
-+		filters[idx].type = EMM_GLOBAL;
-+		filters[idx].enabled   = 1;
-+		filters[idx].filter[0] = 0x83;
-+		filters[idx].mask[0]   = 0xFF;
-+		idx++;
-+
-+		*filter_count = idx;
-+	}
-+
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_biss_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
-+{
-+	if (*emm_filters == NULL)
-+	{
-+		const unsigned int max_filter_count = 15;
-+		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
-+		{
-+			return CS_ERROR;
-+		}
-+
-+		struct s_csystem_emm_filter *filters = *emm_filters;
-+		*filter_count = 0;
-+
-+		int32_t idx = 0;
-+		uint8_t i;
-+
-+		for (i = 0; i < max_filter_count; i++)
-+		{
-+			filters[idx].type = EMM_GLOBAL;
-+			filters[idx].enabled   = 1;
-+			filters[idx].filter[0] = 0x81 + i; // What about table 0x81?
-+			filters[idx].mask[0]   = 0xFF;
-+			idx++;
-+
-+			*filter_count = idx;
-+		}
-+	}
-+	return CS_OK;
-+}
-+
-+static int32_t emu_get_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **UNUSED(emm_filters), unsigned int *UNUSED(filter_count))
-+{
-+	return CS_ERROR;
-+}
-+
-+static int32_t emu_get_emm_filter_adv(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
-+										uint16_t caid, uint32_t provid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
-+{
-+	if (caid_is_viaccess(caid))     return emu_get_via3_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_powervu(caid))      return emu_get_pvu_emm_filter(emm_filters, filter_count, caid, srvid, tsid, onid, ens);
-+	if (caid_is_director(caid))     return emu_get_tan_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_filter(rdr, emm_filters, filter_count, caid, provid);
-+
-+	return CS_ERROR;
-+}
-+
-+const struct s_cardsystem reader_emu =
-+{
-+	.desc = "emu",
-+	.caids = (uint16_t[]){ 0x05, 0x06, 0x0D, 0x0E, 0x10, 0x18, 0x26, 0 },
-+	.do_ecm = emu_do_ecm,
-+	.do_emm = emu_do_emm,
-+	.card_info = emu_card_info,
-+	//.card_init = emu_card_init, // apparently this is not needed at all
-+	.get_emm_type = emu_get_emm_type,
-+	.get_emm_filter = emu_get_emm_filter, // needed to pass checks
-+	.get_emm_filter_adv = emu_get_emm_filter_adv,
-+};
-+
-+/*
-+ * Create the Emu virtual "device" part. This is of type s_cardreader.
-+ * Similar structures are found in the csctapi (Card System Card Terminal API)
-+ * folder for every IFD (InterFace Device), aka smart card reader.
-+ * Since we have no hardware to initialize, we start our Stream Relay server
-+ * with the emu_reader_init() function.
-+ * At Emu shutdown, we remove keys from memory with the emu_close() function.
-+*/
-+
-+#define CR_OK    0
-+#define CR_ERROR 1
-+
-+static int32_t emu_reader_init(struct s_reader *UNUSED(reader))
-+{
-+	int32_t i;
-+	char authtmp[128];
-+
-+	if (cfg.emu_stream_relay_enabled && (stream_server_thread_init == 0))
-+	{
-+		stream_server_thread_init = 1;
-+		SAFE_MUTEX_INIT(&emu_fixed_key_srvid_mutex, NULL);
-+
-+		for (i = 0; i < EMU_STREAM_SERVER_MAX_CONNECTIONS; i++)
-+		{
-+			SAFE_MUTEX_INIT(&emu_fixed_key_data_mutex[i], NULL);
-+			ll_emu_stream_delayed_keys[i] = ll_create("ll_emu_stream_delayed_keys");
-+			memset(&emu_fixed_key_data[i], 0, sizeof(emu_stream_client_key_data));
-+		}
-+
-+		start_thread("stream_key_delayer", stream_key_delayer, NULL, NULL, 1, 1);
-+		cs_log("Stream key delayer initialized");
-+
-+		cs_strncpy(emu_stream_source_host, cfg.emu_stream_source_host, sizeof(emu_stream_source_host));
-+		emu_stream_source_port = cfg.emu_stream_source_port;
-+		emu_stream_relay_port = cfg.emu_stream_relay_port;
-+		emu_stream_emm_enabled = cfg.emu_stream_emm_enabled;
-+
-+		if (cfg.emu_stream_source_auth_user && cfg.emu_stream_source_auth_password)
-+		{
-+			snprintf(authtmp, sizeof(authtmp), "%s:%s", cfg.emu_stream_source_auth_user, cfg.emu_stream_source_auth_password);
-+			b64encode(authtmp, cs_strlen(authtmp), &emu_stream_source_auth);
-+		}
-+		else
-+		{
-+			NULLFREE(emu_stream_source_auth);
-+		}
-+
-+		start_thread("stream_server", stream_server, NULL, NULL, 1, 1);
-+		cs_log("Stream relay server initialized");
-+	}
-+
-+	// Initialize mutex for exclusive access to key database and key file
-+	if (!emu_key_data_mutex_init)
-+	{
-+		SAFE_MUTEX_INIT(&emu_key_data_mutex, NULL);
-+		emu_key_data_mutex_init = 1;
-+	}
-+
-+	return CR_OK;
-+}
-+
-+static int32_t emu_close(struct s_reader *UNUSED(reader))
-+{
-+	cs_log("Reader is shutting down");
-+
-+	// Delete keys from Emu's memory
-+	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
-+	emu_clear_keydata();
-+	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
-+
-+	return CR_OK;
-+}
-+
-+static int32_t emu_get_status(struct s_reader *UNUSED(reader), int32_t *in) { *in = 1; return CR_OK; }
-+static int32_t emu_activate(struct s_reader *UNUSED(reader), struct s_ATR *UNUSED(atr)) { return CR_OK; }
-+static int32_t emu_transmit(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(expectedlen), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
-+static int32_t emu_receive(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
-+static int32_t emu_write_settings(struct s_reader *UNUSED(reader), struct s_cardreader_settings *UNUSED(s)) { return CR_OK; }
-+static int32_t emu_card_write(struct s_reader *UNUSED(pcsc_reader), const uint8_t *UNUSED(buf), uint8_t *UNUSED(cta_res), uint16_t *UNUSED(cta_lr), int32_t UNUSED(l)) { return CR_OK; }
-+static int32_t emu_set_protocol(struct s_reader *UNUSED(rdr), uint8_t *UNUSED(params), uint32_t *UNUSED(length), uint32_t UNUSED(len_request)) { return CR_OK; }
-+
-+const struct s_cardreader cardreader_emu =
-+{
-+	.desc                   = "emu",
-+	.typ                    = R_EMU,
-+	.skip_extra_atr_parsing = 1,
-+	.reader_init            = emu_reader_init,
-+	.get_status             = emu_get_status,
-+	.activate               = emu_activate,
-+	.transmit               = emu_transmit,
-+	.receive                = emu_receive,
-+	.close                  = emu_close,
-+	.write_settings         = emu_write_settings,
-+	.card_write             = emu_card_write,
-+	.set_protocol           = emu_set_protocol,
-+};
-+
-+void add_emu_reader(void)
-+{
-+	// This function is called inside oscam.c and creates an emu [reader] with default
-+	// settings in oscam.server file. If an emu [reader] already exists, it uses that.
-+
-+	LL_ITER itr;
-+	struct s_reader *rdr;
-+	int8_t haveEmuReader = 0;
-+	char emuName[] = "emulator";
-+	char *ctab, *ftab, *emu_auproviders, *disablecrccws_only_for;
-+
-+	// Check if emu [reader] entry already exists in oscam.server file and get it
-+	itr = ll_iter_create(configured_readers);
-+	while ((rdr = ll_iter_next(&itr)))
-+	{
-+		if (rdr->typ == R_EMU)
-+		{
-+			haveEmuReader = 1;
-+			break;
-+		}
-+	}
-+
-+	rdr = NULL;
-+
-+	// If there's no emu [reader] in oscam.server, create one with default settings
-+	if (!haveEmuReader)
-+	{
-+		if (!cs_malloc(&rdr, sizeof(struct s_reader)))
-+		{
-+			return;
-+		}
-+
-+		reader_set_defaults(rdr);
-+
-+		rdr->enable = 1;
-+		rdr->typ = R_EMU;
-+		cs_strncpy(rdr->label, emuName, sizeof(emuName));
-+		cs_strncpy(rdr->device, emuName, sizeof(emuName));
-+
-+		// CAIDs
-+		ctab = strdup("0500,0604,0E00,1010,1801,2600,2602,2610");
-+		chk_caidtab(ctab, &rdr->ctab);
-+		NULLFREE(ctab);
-+
-+		// Idents
-+		ftab = strdup("0500:000000,007400,007800,021110,023800;"
-+					  "0604:000000;"
-+					  "0E00:000000;"
-+					  "1010:000000;"
-+					  "1801:000000,001101,002111,007301;"
-+					  "2600:000000;"
-+					  "2602:000000;"
-+					  "2610:000000;"
-+					 );
-+		chk_ftab(ftab, &rdr->ftab);
-+		NULLFREE(ftab);
-+
-+		// AU providers
-+		emu_auproviders = strdup("0604:010200;0E00:000000;1010:000000;2610:000000;");
-+		chk_ftab(emu_auproviders, &rdr->emu_auproviders);
-+		NULLFREE(emu_auproviders);
-+
-+		// EMM cache
-+		rdr->cachemm = 2;
-+		rdr->rewritemm = 1;
-+		rdr->logemm = 2;
-+		rdr->deviceemm = 1;
-+
-+		// User group
-+		rdr->grp = 0x1ULL;
-+
-+		// Add the "device" part to our emu reader
-+		rdr->crdr = &cardreader_emu;
-+
-+		// Disable CW checksum test for PowerVu
-+		disablecrccws_only_for = strdup("0E00:000000");
-+		chk_ftab(disablecrccws_only_for, &rdr->disablecrccws_only_for);
-+		NULLFREE(disablecrccws_only_for);
-+
-+		reader_fixups_fn(rdr);
-+		ll_append(configured_readers, rdr);
-+	}
-+
-+	// Set DVB Api delayer option
-+#ifdef HAVE_DVBAPI
-+	if (cfg.dvbapi_enabled && cfg.dvbapi_delayer < 60)
-+	{
-+		cfg.dvbapi_delayer = 60;
-+	}
-+#endif
-+
-+	cs_log("OSCam-Emu version %d", EMU_VERSION);
-+}
-+
-+#endif // WITH_EMU
---- module-emulator-cryptoworks.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-cryptoworks.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-cryptoworks.c
+===================================================================
+--- module-emulator-cryptoworks.c	(nonexistent)
++++ module-emulator-cryptoworks.c	(working copy)
 @@ -0,0 +1,688 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -2837,8 +1958,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-cryptoworks.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-cryptoworks.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-cryptoworks.h
+===================================================================
+--- module-emulator-cryptoworks.h	(nonexistent)
++++ module-emulator-cryptoworks.h	(working copy)
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_CRYPTOWORKS_H
 +#define MODULE_EMULATOR_CRYPTOWORKS_H
@@ -2850,8 +1973,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_CRYPTOWORKS_H
---- module-emulator-director.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-director.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-director.c
+===================================================================
+--- module-emulator-director.c	(nonexistent)
++++ module-emulator-director.c	(working copy)
 @@ -0,0 +1,642 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -3495,8 +2620,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-director.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-director.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-director.h
+===================================================================
+--- module-emulator-director.h	(nonexistent)
++++ module-emulator-director.h	(working copy)
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_DIRECTOR_H
 +#define MODULE_EMULATOR_DIRECTOR_H
@@ -3509,8 +2636,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_DIRECTOR_H
---- module-emulator-irdeto.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-irdeto.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-irdeto.c
+===================================================================
+--- module-emulator-irdeto.c	(nonexistent)
++++ module-emulator-irdeto.c	(working copy)
 @@ -0,0 +1,602 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -4114,8 +3243,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-irdeto.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-irdeto.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-irdeto.h
+===================================================================
+--- module-emulator-irdeto.h	(nonexistent)
++++ module-emulator-irdeto.h	(working copy)
 @@ -0,0 +1,15 @@
 +#ifndef MODULE_EMULATOR_IRDETO_H
 +#define MODULE_EMULATOR_IRDETO_H
@@ -4132,8 +3263,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_IRDETO_H
---- module-emulator-nagravision.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-nagravision.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-nagravision.c
+===================================================================
+--- module-emulator-nagravision.c	(nonexistent)
++++ module-emulator-nagravision.c	(working copy)
 @@ -0,0 +1,376 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -4511,8 +3644,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-nagravision.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-nagravision.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-nagravision.h
+===================================================================
+--- module-emulator-nagravision.h	(nonexistent)
++++ module-emulator-nagravision.h	(working copy)
 @@ -0,0 +1,10 @@
 +#ifndef MODULE_EMULATOR_NAGRAVISION_H
 +#define MODULE_EMULATOR_NAGRAVISION_H
@@ -4524,8 +3659,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_NAGRAVISION_H
---- module-emulator-osemu.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-osemu.c	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-osemu.c
+===================================================================
+--- module-emulator-osemu.c	(nonexistent)
++++ module-emulator-osemu.c	(working copy)
 @@ -0,0 +1,972 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -5499,8 +4636,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-osemu.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-osemu.h	2020-09-23 22:57:35.772490349 +0200
+Index: module-emulator-osemu.h
+===================================================================
+--- module-emulator-osemu.h	(nonexistent)
++++ module-emulator-osemu.h	(working copy)
 @@ -0,0 +1,95 @@
 +#ifndef MODULE_EMULATOR_OSEMU_H_
 +#define MODULE_EMULATOR_OSEMU_H_
@@ -5597,8 +4736,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_H_
---- module-emulator-powervu.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-powervu.c	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-powervu.c
+===================================================================
+--- module-emulator-powervu.c	(nonexistent)
++++ module-emulator-powervu.c	(working copy)
 @@ -0,0 +1,2691 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -8291,8 +7432,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-powervu.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-powervu.h	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-powervu.h
+===================================================================
+--- module-emulator-powervu.h	(nonexistent)
++++ module-emulator-powervu.h	(working copy)
 @@ -0,0 +1,59 @@
 +#ifndef MODULE_EMULATOR_POWERVU_H
 +#define MODULE_EMULATOR_POWERVU_H
@@ -8353,8 +7496,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_POWERVU_H
---- module-emulator-streamserver.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-streamserver.c	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-streamserver.c
+===================================================================
+--- module-emulator-streamserver.c	(nonexistent)
++++ module-emulator-streamserver.c	(working copy)
 @@ -0,0 +1,1802 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -10158,8 +9303,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-streamserver.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-streamserver.h	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-streamserver.h
+===================================================================
+--- module-emulator-streamserver.h	(nonexistent)
++++ module-emulator-streamserver.h	(working copy)
 @@ -0,0 +1,90 @@
 +#ifndef MODULE_EMULATOR_STREAMSERVER_H_
 +#define MODULE_EMULATOR_STREAMSERVER_H_
@@ -10251,8 +9398,10 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_STREAMSERVER_H_
---- module-emulator-viaccess.c	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-viaccess.c	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-viaccess.c
+===================================================================
+--- module-emulator-viaccess.c	(nonexistent)
++++ module-emulator-viaccess.c	(working copy)
 @@ -0,0 +1,1183 @@
 +#define MODULE_LOG_PREFIX "emu"
 +
@@ -11437,8 +10586,10 @@
 +}
 +
 +#endif // WITH_EMU
---- module-emulator-viaccess.h	1970-01-01 01:00:00.000000000 +0100
-+++ module-emulator-viaccess.h	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator-viaccess.h
+===================================================================
+--- module-emulator-viaccess.h	(nonexistent)
++++ module-emulator-viaccess.h	(working copy)
 @@ -0,0 +1,11 @@
 +#ifndef MODULE_EMULATOR_VIACCESS_H
 +#define MODULE_EMULATOR_VIACCESS_H
@@ -11451,8 +10602,919 @@
 +#endif // WITH_EMU
 +
 +#endif // MODULE_EMULATOR_VIACCESS_H
---- oscam.c	2020-09-23 22:18:25.000000000 +0200
-+++ oscam.c	2020-09-23 22:57:35.776549489 +0200
+Index: module-emulator.c
+===================================================================
+--- module-emulator.c	(nonexistent)
++++ module-emulator.c	(working copy)
+@@ -0,0 +1,904 @@
++#define MODULE_LOG_PREFIX "emu"
++
++#include "globals.h"
++
++#ifdef WITH_EMU
++
++#include "module-emulator-osemu.h"
++#include "module-emulator-streamserver.h"
++#include "module-emulator-biss.h"
++#include "module-emulator-irdeto.h"
++#include "module-emulator-powervu.h"
++#include "oscam-conf-chk.h"
++#include "oscam-config.h"
++#include "oscam-reader.h"
++#include "oscam-string.h"
++
++/*
++ * Readers in OSCam consist of 2 basic parts.
++ * The hardware or the device part. This is where physical smart cards are inserted
++ * and made available to OSCam.
++ * The software or the emulation part. This is where the actual card reading is done,
++ * including ecm and emm processing (i.e emulation of the various cryptosystems).
++ * In the Emu reader, the device part has no meaning, but we have to create it in
++ * order to be compatible with OSCam's reader structure.
++*/
++
++/*
++ * Create the Emu "emulation" part. This is of type s_cardsystem.
++ * Similar structures are found in the main sources folder (files reader-xxxxxx.c)
++ * for every cryptosystem supported by OSCam.
++ * Here we read keys from our virtual card (aka the SoftCam.Key file) and we inform
++ * OSCam about them. This is done with the emu_card_info() function. Keep in mind
++ * that Emu holds all its keys to separate structures for faster access.
++ * In addition, ECM and EMM requests are processed here, with the emu_do_ecm() and
++ * emu_do_emm() functions.
++*/
++
++#define CS_OK    1
++#define CS_ERROR 0
++
++extern char cs_confdir[128];
++static int8_t emu_key_data_mutex_init = 0;
++pthread_mutex_t emu_key_data_mutex;
++
++static void set_hexserial_to_version(struct s_reader *rdr)
++{
++	char cVersion[32];
++	uint32_t version = EMU_VERSION;
++	uint8_t hversion[2];
++	memset(hversion, 0, 2);
++	snprintf(cVersion, sizeof(cVersion), "%04d", version);
++	char_to_bin(hversion, cVersion, 4);
++	rdr->hexserial[3] = hversion[0];
++	rdr->hexserial[4] = hversion[1];
++}
++
++static void set_prids(struct s_reader *rdr)
++{
++	int32_t i, j;
++
++	rdr->nprov = 0;
++
++	for (i = 0; (i < rdr->emu_auproviders.nfilts) && (rdr->nprov < CS_MAXPROV); i++)
++	{
++		for (j = 0; (j < rdr->emu_auproviders.filts[i].nprids) && (rdr->nprov < CS_MAXPROV); j++)
++		{
++			i2b_buf(4, rdr->emu_auproviders.filts[i].prids[j], rdr->prid[i]);
++			rdr->nprov++;
++		}
++	}
++}
++
++static void emu_add_entitlement(struct s_reader *rdr, uint16_t caid, uint32_t provid, uint8_t *key, char *keyName, uint32_t keyLength, uint8_t isData)
++{
++	if (!rdr->ll_entitlements)
++	{
++		rdr->ll_entitlements = ll_create("ll_entitlements");
++	}
++
++	S_ENTITLEMENT *item;
++	if (cs_malloc(&item, sizeof(S_ENTITLEMENT)))
++	{
++		// fill item
++		item->caid = caid;
++		item->provid = provid;
++		item->id = 0;
++		item->class = 0;
++		item->start = 0;
++		item->end = 2147472000;
++		item->type = 0;
++		item->isKey = 1;
++		memcpy(item->name, keyName, 8);
++		item->key = key;
++		item->keyLength = keyLength;
++		item->isData = isData;
++
++		// add item
++		ll_append(rdr->ll_entitlements, item);
++	}
++}
++
++static void refresh_entitlements(struct s_reader *rdr)
++{
++	uint32_t i;
++	uint16_t caid;
++	KeyData *tmpKeyData;
++	LL_ITER itr;
++	biss2_rsa_key_t *item;
++
++	cs_clear_entitlement(rdr);
++
++	for (i = 0; i < StreamKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, b2i(2, StreamKeys.EmuKeys[i].key), StreamKeys.EmuKeys[i].provider, StreamKeys.EmuKeys[i].key,
++							StreamKeys.EmuKeys[i].keyName, StreamKeys.EmuKeys[i].keyLength, 1);
++	}
++
++	for (i = 0; i < ViKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x0500, ViKeys.EmuKeys[i].provider, ViKeys.EmuKeys[i].key,
++							ViKeys.EmuKeys[i].keyName, ViKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < IrdetoKeys.keyCount; i++)
++	{
++		tmpKeyData = &IrdetoKeys.EmuKeys[i];
++		do
++		{
++			emu_add_entitlement(rdr, tmpKeyData->provider >> 8, tmpKeyData->provider & 0xFF,
++								tmpKeyData->key, tmpKeyData->keyName, tmpKeyData->keyLength, 0);
++
++			tmpKeyData = tmpKeyData->nextKey;
++		}
++		while (tmpKeyData != NULL);
++	}
++
++	for (i = 0; i < CwKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, CwKeys.EmuKeys[i].provider >> 8, CwKeys.EmuKeys[i].provider & 0xFF,
++							CwKeys.EmuKeys[i].key, CwKeys.EmuKeys[i].keyName, CwKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < PowervuKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x0E00, PowervuKeys.EmuKeys[i].provider, PowervuKeys.EmuKeys[i].key,
++							PowervuKeys.EmuKeys[i].keyName, PowervuKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < TandbergKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x1010, TandbergKeys.EmuKeys[i].provider, TandbergKeys.EmuKeys[i].key,
++							TandbergKeys.EmuKeys[i].keyName, TandbergKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	for (i = 0; i < NagraKeys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x1801, NagraKeys.EmuKeys[i].provider, NagraKeys.EmuKeys[i].key,
++							NagraKeys.EmuKeys[i].keyName, NagraKeys.EmuKeys[i].keyLength, 0);
++	}
++
++	// Session words for BISS1 mode 1/E (caid 2600) and BISS2 mode 1/E (caid 2602)
++	for (i = 0; i < BissSWs.keyCount; i++)
++	{
++		caid = (BissSWs.EmuKeys[i].keyLength == 8) ? 0x2600 : 0x2602;
++		emu_add_entitlement(rdr, caid, BissSWs.EmuKeys[i].provider, BissSWs.EmuKeys[i].key,
++							BissSWs.EmuKeys[i].keyName, BissSWs.EmuKeys[i].keyLength, 0);
++	}
++
++	// Session keys (ECM keys) for BISS2 mode CA
++	for (i = 0; i < Biss2Keys.keyCount; i++)
++	{
++		emu_add_entitlement(rdr, 0x2610, Biss2Keys.EmuKeys[i].provider, Biss2Keys.EmuKeys[i].key,
++							Biss2Keys.EmuKeys[i].keyName, Biss2Keys.EmuKeys[i].keyLength, 0);
++	}
++
++	// RSA keys (EMM keys) for BISS2 mode CA
++	itr = ll_iter_create(rdr->ll_biss2_rsa_keys);
++	while ((item = ll_iter_next(&itr)))
++	{
++		emu_add_entitlement(rdr, 0x2610, 0, item->ekid, "RSAPRI", 8, 0);
++	}
++}
++
++static int32_t emu_do_ecm(struct s_reader *rdr, const ECM_REQUEST *er, struct s_ecm_answer *ea)
++{
++	if (!emu_process_ecm(rdr, er, ea->cw, &ea->cw_ex))
++	{
++		return CS_OK;
++	}
++
++	return CS_ERROR;
++}
++
++static int32_t emu_do_emm(struct s_reader *rdr, EMM_PACKET *emm)
++{
++	uint32_t keysAdded = 0;
++
++	if (emm->emmlen < 3)
++	{
++		return CS_ERROR;
++	}
++
++	if (SCT_LEN(emm->emm) > emm->emmlen)
++	{
++		return CS_ERROR;
++	}
++
++	if (!emu_process_emm(rdr, b2i(2, emm->caid), emm->emm, &keysAdded))
++	{
++		if (keysAdded > 0)
++		{
++			refresh_entitlements(rdr);
++		}
++
++		return CS_OK;
++	}
++
++	return CS_ERROR;
++}
++
++static int32_t emu_card_info(struct s_reader *rdr)
++{
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++
++	// Delete keys from Emu's memory
++	emu_clear_keydata();
++
++	// Delete BISS2 mode CA RSA keys
++	ll_destroy_data(&rdr->ll_biss2_rsa_keys);
++
++	// Read keys built in the OSCam-Emu binary
++	emu_read_keymemory(rdr);
++
++	// Read keys from SoftCam.Key file
++	emu_set_keyfile_path(cs_confdir);
++
++	if (!emu_read_keyfile(rdr, cs_confdir))
++	{
++		if (emu_read_keyfile(rdr, "/var/keys/"))
++		{
++			emu_set_keyfile_path("/var/keys/");
++		}
++	}
++
++	// Read BISS2 mode CA RSA keys from PEM files
++	biss_read_pem(rdr, BISS2_MAX_RSA_KEYS);
++
++	cs_log("Total keys in memory: W:%d V:%d N:%d I:%d F:%d G:%d P:%d T:%d A:%d",
++			CwKeys.keyCount, ViKeys.keyCount, NagraKeys.keyCount, IrdetoKeys.keyCount,
++			BissSWs.keyCount, Biss2Keys.keyCount, PowervuKeys.keyCount, TandbergKeys.keyCount,
++			StreamKeys.keyCount);
++
++	// Inform OSCam about all available keys.
++	// This is used for listing the "entitlements" in the webif's reader page.
++	refresh_entitlements(rdr);
++
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	set_prids(rdr);
++
++	set_hexserial_to_version(rdr);
++
++	return CS_OK;
++}
++
++/*
++static int32_t emu_card_init(struct s_reader *UNUSED(rdr), struct s_ATR *UNUSED(atr))
++{
++	return CS_ERROR;
++}
++*/
++
++int32_t emu_get_via3_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	uint32_t provid = 0;
++
++	if(ep->emm[3] == 0x90 && ep->emm[4] == 0x03)
++	{
++		provid = b2i(3, ep->emm + 5);
++		provid &= 0xFFFFF0;
++		i2b_buf(4, provid, ep->provid);
++	}
++
++	switch (ep->emm[0])
++	{
++		case 0x88:
++			ep->type = UNIQUE;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, 4);
++			rdr_log_dbg(rdr, D_EMM, "UNIQUE");
++			return 1;
++
++		case 0x8A:
++		case 0x8B:
++			ep->type = GLOBAL;
++			rdr_log_dbg(rdr, D_EMM, "GLOBAL");
++			return 1;
++
++		case 0x8C:
++		case 0x8D:
++			ep->type = SHARED;
++			rdr_log_dbg(rdr, D_EMM, "SHARED (part)");
++			// We need those packets to pass otherwise we would never
++			// be able to complete EMM reassembly
++			return 1;
++
++		case 0x8E:
++			ep->type = SHARED;
++			rdr_log_dbg(rdr, D_EMM, "SHARED");
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 3, 3);
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++int32_t emu_get_ird2_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	int32_t l = (ep->emm[3] & 0x07);
++	int32_t base = (ep->emm[3] >> 3);
++	char dumprdrserial[l * 3], dumpemmserial[l * 3];
++
++	switch (l)
++	{
++		case 0:
++			// global emm, 0 bytes addressed
++			ep->type = GLOBAL;
++			rdr_log_dbg(rdr, D_EMM, "GLOBAL base = %02x", base);
++			return 1;
++
++		case 2:
++			// shared emm, 2 bytes addressed
++			ep->type = SHARED;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, l);
++			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
++			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
++			rdr_log_dbg_sensitive(rdr, D_EMM, "SHARED l = %d ep = {%s} rdr = {%s} base = %02x",
++									l, dumpemmserial, dumprdrserial, base);
++			return 1;
++
++		case 3:
++			// unique emm, 3 bytes addressed
++			ep->type = UNIQUE;
++			memset(ep->hexserial, 0, 8);
++			memcpy(ep->hexserial, ep->emm + 4, l);
++			cs_hexdump(1, rdr->hexserial, l, dumprdrserial, sizeof(dumprdrserial));
++			cs_hexdump(1, ep->hexserial, l, dumpemmserial, sizeof(dumpemmserial));
++			rdr_log_dbg_sensitive(rdr, D_EMM, "UNIQUE l = %d ep = {%s} rdr = {%s} base = %02x",
++									l, dumpemmserial, dumprdrserial, base);
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++int32_t emu_get_pvu_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	if (ep->emm[0] == 0x82)
++	{
++		ep->type = UNIQUE;
++		memset(ep->hexserial, 0, 8);
++		memcpy(ep->hexserial, ep->emm + 12, 4);
++	}
++	else
++	{
++		ep->type = UNKNOWN;
++		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++	}
++	return 1;
++}
++
++int32_t emu_get_tan_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	if (ep->emm[0] == 0x82 || ep->emm[0] == 0x83)
++	{
++		ep->type = GLOBAL;
++	}
++	else
++	{
++		ep->type = UNKNOWN;
++		rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++	}
++	return 1;
++}
++
++int32_t emu_get_biss_emm_type(EMM_PACKET *ep, struct s_reader *rdr)
++{
++	switch (ep->emm[0])
++	{
++		case 0x81: // Spec say this is for EMM, but oscam (and all other crypto systems) use it for ECM
++		case 0x82:
++		case 0x83:
++		case 0x84:
++		case 0x85:
++		case 0x86:
++		case 0x87:
++		case 0x88:
++		case 0x89:
++		case 0x8A:
++		case 0x8B:
++		case 0x8C:
++		case 0x8D:
++		case 0x8E:
++		case 0x8F:
++			ep->type = GLOBAL;
++			return 1;
++
++		default:
++			ep->type = UNKNOWN;
++			rdr_log_dbg(rdr, D_EMM, "UNKNOWN");
++			return 1;
++	}
++}
++
++static int32_t emu_get_emm_type(struct emm_packet_t *ep, struct s_reader *rdr)
++{
++	uint16_t caid = b2i(2, ep->caid);
++
++	if (caid_is_viaccess(caid))     return emu_get_via3_emm_type(ep, rdr);
++	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_type(ep, rdr);
++	if (caid_is_powervu(caid))      return emu_get_pvu_emm_type(ep, rdr);
++	if (caid_is_director(caid))     return emu_get_tan_emm_type(ep, rdr);
++	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_type(ep, rdr);
++
++	return CS_ERROR;
++}
++
++FILTER *get_emu_prids_for_caid(struct s_reader *rdr, uint16_t caid)
++{
++	int32_t i;
++
++	for (i = 0; i < rdr->emu_auproviders.nfilts; i++)
++	{
++		if (caid == rdr->emu_auproviders.filts[i].caid)
++		{
++			return &rdr->emu_auproviders.filts[i];
++		}
++	}
++
++	return NULL;
++}
++
++static int32_t emu_get_via3_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 1;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x8A;
++		filters[idx].mask[0]   = 0xFE;
++		filters[idx].filter[3] = 0x80;
++		filters[idx].mask[3]   = 0x80;
++		idx++;
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_ird2_emm_filter(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t caid, uint32_t UNUSED(provid))
++{
++	uint8_t hexserial[3], prid[4];
++	FILTER *emu_provids;
++	int8_t have_provid = 0, have_serial = 0;
++	int32_t i;
++
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	if(irdeto2_get_hexserial(caid, hexserial))
++	{
++		have_serial = 1;
++	}
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	emu_provids = get_emu_prids_for_caid(rdr, caid);
++	if (emu_provids != NULL && emu_provids->nprids > 0)
++	{
++		have_provid = 1;
++	}
++
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = have_serial + (2 * (have_provid ? emu_provids->nprids : 0));
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		unsigned int idx = 0;
++
++		if (have_serial)
++		{
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFB;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], hexserial, 3);
++			memset(&filters[idx].mask[2], 0xFF, 3);
++			idx++;
++		}
++
++		for (i = 0; have_provid && i < emu_provids->nprids; i++)
++		{
++			i2b_buf(4, emu_provids->prids[i], prid);
++
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFB;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], &prid[1], 3);
++			memset(&filters[idx].mask[2], 0xFF, 3);
++			idx++;
++
++			filters[idx].type = EMM_SHARED;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x82;
++			filters[idx].mask[0]   = 0xFF;
++			filters[idx].filter[1] = 0xFA;
++			filters[idx].mask[1]   = 0x07;
++			memcpy(&filters[idx].filter[2], &prid[1], 2);
++			memset(&filters[idx].mask[2], 0xFF, 2);
++			idx++;
++		}
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_pvu_emm_filter(struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
++										uint16_t caid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
++{
++	uint8_t hexserials[32][4];
++	uint32_t i, count = 0;
++
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	count = powervu_get_hexserials_new(hexserials, 32, caid, tsid, onid, ens);
++	if (count == 0)
++	{
++		count = powervu_get_hexserials(hexserials, 32, srvid);
++		if (count == 0)
++		{
++			SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++			return CS_ERROR;
++		}
++	}
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = count;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		for (i = 0; i < count; i++)
++		{
++			filters[idx].type = EMM_UNIQUE;
++			filters[idx].enabled    = 1;
++			filters[idx].filter[0]  = 0x82;
++			filters[idx].filter[10] = hexserials[i][0];
++			filters[idx].filter[11] = hexserials[i][1];
++			filters[idx].filter[12] = hexserials[i][2];
++			filters[idx].filter[13] = hexserials[i][3];
++			filters[idx].mask[0]    = 0xFF;
++			filters[idx].mask[10]   = 0xFF;
++			filters[idx].mask[11]   = 0xFF;
++			filters[idx].mask[12]   = 0xFF;
++			filters[idx].mask[13]   = 0xFF;
++			idx++;
++		}
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_tan_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 2;
++		uint8_t buf[8];
++
++		if (!emu_find_key('T', 0x40, 0, "MK", buf, 8, 0, 0, 0, NULL) &&
++			!emu_find_key('T', 0x40, 0, "MK01", buf, 8, 0, 0, 0, NULL))
++		{
++			return CS_ERROR;
++		}
++
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x82;
++		filters[idx].mask[0]   = 0xFF;
++		idx++;
++
++		filters[idx].type = EMM_GLOBAL;
++		filters[idx].enabled   = 1;
++		filters[idx].filter[0] = 0x83;
++		filters[idx].mask[0]   = 0xFF;
++		idx++;
++
++		*filter_count = idx;
++	}
++
++	return CS_OK;
++}
++
++static int32_t emu_get_biss_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count, uint16_t UNUSED(caid), uint32_t UNUSED(provid))
++{
++	if (*emm_filters == NULL)
++	{
++		const unsigned int max_filter_count = 15;
++		if (!cs_malloc(emm_filters, max_filter_count * sizeof(struct s_csystem_emm_filter)))
++		{
++			return CS_ERROR;
++		}
++
++		struct s_csystem_emm_filter *filters = *emm_filters;
++		*filter_count = 0;
++
++		int32_t idx = 0;
++		uint8_t i;
++
++		for (i = 0; i < max_filter_count; i++)
++		{
++			filters[idx].type = EMM_GLOBAL;
++			filters[idx].enabled   = 1;
++			filters[idx].filter[0] = 0x81 + i; // What about table 0x81?
++			filters[idx].mask[0]   = 0xFF;
++			idx++;
++
++			*filter_count = idx;
++		}
++	}
++	return CS_OK;
++}
++
++static int32_t emu_get_emm_filter(struct s_reader *UNUSED(rdr), struct s_csystem_emm_filter **UNUSED(emm_filters), unsigned int *UNUSED(filter_count))
++{
++	return CS_ERROR;
++}
++
++static int32_t emu_get_emm_filter_adv(struct s_reader *rdr, struct s_csystem_emm_filter **emm_filters, unsigned int *filter_count,
++										uint16_t caid, uint32_t provid, uint16_t srvid, uint16_t tsid, uint16_t onid, uint32_t ens)
++{
++	if (caid_is_viaccess(caid))     return emu_get_via3_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_irdeto(caid))       return emu_get_ird2_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_powervu(caid))      return emu_get_pvu_emm_filter(emm_filters, filter_count, caid, srvid, tsid, onid, ens);
++	if (caid_is_director(caid))     return emu_get_tan_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++	if (caid_is_biss_dynamic(caid)) return emu_get_biss_emm_filter(rdr, emm_filters, filter_count, caid, provid);
++
++	return CS_ERROR;
++}
++
++const struct s_cardsystem reader_emu =
++{
++	.desc = "emu",
++	.caids = (uint16_t[]){ 0x05, 0x06, 0x0D, 0x0E, 0x10, 0x18, 0x26, 0 },
++	.do_ecm = emu_do_ecm,
++	.do_emm = emu_do_emm,
++	.card_info = emu_card_info,
++	//.card_init = emu_card_init, // apparently this is not needed at all
++	.get_emm_type = emu_get_emm_type,
++	.get_emm_filter = emu_get_emm_filter, // needed to pass checks
++	.get_emm_filter_adv = emu_get_emm_filter_adv,
++};
++
++/*
++ * Create the Emu virtual "device" part. This is of type s_cardreader.
++ * Similar structures are found in the csctapi (Card System Card Terminal API)
++ * folder for every IFD (InterFace Device), aka smart card reader.
++ * Since we have no hardware to initialize, we start our Stream Relay server
++ * with the emu_reader_init() function.
++ * At Emu shutdown, we remove keys from memory with the emu_close() function.
++*/
++
++#define CR_OK    0
++#define CR_ERROR 1
++
++static int32_t emu_reader_init(struct s_reader *UNUSED(reader))
++{
++	int32_t i;
++	char authtmp[128];
++
++	if (cfg.emu_stream_relay_enabled && (stream_server_thread_init == 0))
++	{
++		stream_server_thread_init = 1;
++		SAFE_MUTEX_INIT(&emu_fixed_key_srvid_mutex, NULL);
++
++		for (i = 0; i < EMU_STREAM_SERVER_MAX_CONNECTIONS; i++)
++		{
++			SAFE_MUTEX_INIT(&emu_fixed_key_data_mutex[i], NULL);
++			ll_emu_stream_delayed_keys[i] = ll_create("ll_emu_stream_delayed_keys");
++			memset(&emu_fixed_key_data[i], 0, sizeof(emu_stream_client_key_data));
++		}
++
++		start_thread("stream_key_delayer", stream_key_delayer, NULL, NULL, 1, 1);
++		cs_log("Stream key delayer initialized");
++
++		cs_strncpy(emu_stream_source_host, cfg.emu_stream_source_host, sizeof(emu_stream_source_host));
++		emu_stream_source_port = cfg.emu_stream_source_port;
++		emu_stream_relay_port = cfg.emu_stream_relay_port;
++		emu_stream_emm_enabled = cfg.emu_stream_emm_enabled;
++
++		if (cfg.emu_stream_source_auth_user && cfg.emu_stream_source_auth_password)
++		{
++			snprintf(authtmp, sizeof(authtmp), "%s:%s", cfg.emu_stream_source_auth_user, cfg.emu_stream_source_auth_password);
++			b64encode(authtmp, cs_strlen(authtmp), &emu_stream_source_auth);
++		}
++		else
++		{
++			NULLFREE(emu_stream_source_auth);
++		}
++
++		start_thread("stream_server", stream_server, NULL, NULL, 1, 1);
++		cs_log("Stream relay server initialized");
++	}
++
++	// Initialize mutex for exclusive access to key database and key file
++	if (!emu_key_data_mutex_init)
++	{
++		SAFE_MUTEX_INIT(&emu_key_data_mutex, NULL);
++		emu_key_data_mutex_init = 1;
++	}
++
++	return CR_OK;
++}
++
++static int32_t emu_close(struct s_reader *UNUSED(reader))
++{
++	cs_log("Reader is shutting down");
++
++	// Delete keys from Emu's memory
++	SAFE_MUTEX_LOCK(&emu_key_data_mutex);
++	emu_clear_keydata();
++	SAFE_MUTEX_UNLOCK(&emu_key_data_mutex);
++
++	return CR_OK;
++}
++
++static int32_t emu_get_status(struct s_reader *UNUSED(reader), int32_t *in) { *in = 1; return CR_OK; }
++static int32_t emu_activate(struct s_reader *UNUSED(reader), struct s_ATR *UNUSED(atr)) { return CR_OK; }
++static int32_t emu_transmit(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(expectedlen), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
++static int32_t emu_receive(struct s_reader *UNUSED(reader), uint8_t *UNUSED(buffer), uint32_t UNUSED(size), uint32_t UNUSED(delay), uint32_t UNUSED(timeout)) { return CR_OK; }
++static int32_t emu_write_settings(struct s_reader *UNUSED(reader), struct s_cardreader_settings *UNUSED(s)) { return CR_OK; }
++static int32_t emu_card_write(struct s_reader *UNUSED(pcsc_reader), const uint8_t *UNUSED(buf), uint8_t *UNUSED(cta_res), uint16_t *UNUSED(cta_lr), int32_t UNUSED(l)) { return CR_OK; }
++static int32_t emu_set_protocol(struct s_reader *UNUSED(rdr), uint8_t *UNUSED(params), uint32_t *UNUSED(length), uint32_t UNUSED(len_request)) { return CR_OK; }
++
++const struct s_cardreader cardreader_emu =
++{
++	.desc                   = "emu",
++	.typ                    = R_EMU,
++	.skip_extra_atr_parsing = 1,
++	.reader_init            = emu_reader_init,
++	.get_status             = emu_get_status,
++	.activate               = emu_activate,
++	.transmit               = emu_transmit,
++	.receive                = emu_receive,
++	.close                  = emu_close,
++	.write_settings         = emu_write_settings,
++	.card_write             = emu_card_write,
++	.set_protocol           = emu_set_protocol,
++};
++
++void add_emu_reader(void)
++{
++	// This function is called inside oscam.c and creates an emu [reader] with default
++	// settings in oscam.server file. If an emu [reader] already exists, it uses that.
++
++	LL_ITER itr;
++	struct s_reader *rdr;
++	int8_t haveEmuReader = 0;
++	char emuName[] = "emulator";
++	char *ctab, *ftab, *emu_auproviders, *disablecrccws_only_for;
++
++	// Check if emu [reader] entry already exists in oscam.server file and get it
++	itr = ll_iter_create(configured_readers);
++	while ((rdr = ll_iter_next(&itr)))
++	{
++		if (rdr->typ == R_EMU)
++		{
++			haveEmuReader = 1;
++			break;
++		}
++	}
++
++	rdr = NULL;
++
++	// If there's no emu [reader] in oscam.server, create one with default settings
++	if (!haveEmuReader)
++	{
++		if (!cs_malloc(&rdr, sizeof(struct s_reader)))
++		{
++			return;
++		}
++
++		reader_set_defaults(rdr);
++
++		rdr->enable = 1;
++		rdr->typ = R_EMU;
++		cs_strncpy(rdr->label, emuName, sizeof(emuName));
++		cs_strncpy(rdr->device, emuName, sizeof(emuName));
++
++		// CAIDs
++		ctab = strdup("0500,0604,0E00,1010,1801,2600,2602,2610");
++		chk_caidtab(ctab, &rdr->ctab);
++		NULLFREE(ctab);
++
++		// Idents
++		ftab = strdup("0500:000000,007400,007800,021110,023800;"
++					  "0604:000000;"
++					  "0E00:000000;"
++					  "1010:000000;"
++					  "1801:000000,001101,002111,007301;"
++					  "2600:000000;"
++					  "2602:000000;"
++					  "2610:000000;"
++					 );
++		chk_ftab(ftab, &rdr->ftab);
++		NULLFREE(ftab);
++
++		// AU providers
++		emu_auproviders = strdup("0604:010200;0E00:000000;1010:000000;2610:000000;");
++		chk_ftab(emu_auproviders, &rdr->emu_auproviders);
++		NULLFREE(emu_auproviders);
++
++		// EMM cache
++		rdr->cachemm = 2;
++		rdr->rewritemm = 1;
++		rdr->logemm = 2;
++		rdr->deviceemm = 1;
++
++		// User group
++		rdr->grp = 0x1ULL;
++
++		// Add the "device" part to our emu reader
++		rdr->crdr = &cardreader_emu;
++
++		// Disable CW checksum test for PowerVu
++		disablecrccws_only_for = strdup("0E00:000000");
++		chk_ftab(disablecrccws_only_for, &rdr->disablecrccws_only_for);
++		NULLFREE(disablecrccws_only_for);
++
++		reader_fixups_fn(rdr);
++		ll_append(configured_readers, rdr);
++	}
++
++	// Set DVB Api delayer option
++#ifdef HAVE_DVBAPI
++	if (cfg.dvbapi_enabled && cfg.dvbapi_delayer < 60)
++	{
++		cfg.dvbapi_delayer = 60;
++	}
++#endif
++
++	cs_log("OSCam-Emu version %d", EMU_VERSION);
++}
++
++#endif // WITH_EMU
+Index: oscam.c
+===================================================================
+--- oscam.c	(revision 11657)
++++ oscam.c	(working copy)
 @@ -41,6 +41,11 @@
  #include "reader-common.h"
  #include "module-gbox.h"
@@ -11465,7 +11527,7 @@
  #ifdef WITH_SSL
  #include <openssl/crypto.h>
  #include <openssl/ssl.h>
-@@ -436,6 +441,8 @@
+@@ -437,6 +442,8 @@
  		case CLOCK_TYPE_MONOTONIC: write_conf(CLOCKFIX, "Clockfix with monotonic clock"); break;
  	}
  	write_conf(IPV6SUPPORT, "IPv6 support");
@@ -11474,7 +11536,7 @@
  
  	fprintf(fp, "\n");
  	write_conf(MODULE_CAMD33, "camd 3.3x");
-@@ -1833,6 +1840,9 @@
+@@ -1834,6 +1841,9 @@
  
  	init_sidtab();
  	init_readerdb();
@@ -11484,7 +11546,7 @@
  	cfg.account = init_userdb();
  	init_signal();
  	init_provid();
-@@ -1920,6 +1930,9 @@
+@@ -1921,6 +1931,9 @@
  if(!cfg.gsms_dis)
  	{ stop_sms_sender(); }
  #endif
@@ -11494,13 +11556,10 @@
  	webif_close();
  	azbox_close();
  	coolapi_close_all();
---- .travis.yml	1970-01-01 01:00:00.000000000 +0100
-+++ .travis.yml	2020-09-23 22:57:35.768431210 +0200
-@@ -0,0 +1,2 @@
-+language: cpp
-+script: ./config.sh -E all && make
---- webif/config/dvbapi.html	2020-09-23 22:18:24.000000000 +0200
-+++ webif/config/dvbapi.html	2020-09-23 22:57:35.776549489 +0200
+Index: webif/config/dvbapi.html
+===================================================================
+--- webif/config/dvbapi.html	(revision 11657)
++++ webif/config/dvbapi.html	(working copy)
 @@ -56,7 +56,7 @@
  			</TD>
  		</TR>
@@ -11516,3 +11575,4 @@
  			</TD>
 -		</TR> -->
 +		</TR>
+\ No newline at end of file


### PR DESCRIPTION
fix build warning

module-emulator-powervu.c: In function ‘powervu_emm’:
module-emulator-powervu.c:2254:2: warning: array subscript 40 is outside array bounds of ‘uint8_t[30]’ {aka ‘unsigned char[30]’} [-Warray-bounds]
 2254 |  memcpy(data + 0x28, padding, 0x18);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
module-emulator-powervu.c:2338:35: note: while referencing ‘data’
 2338 |  uint8_t hashModeEmm, modeUnmask, data[30], mask[16];
      |                                   ^~~~